### PR TITLE
feat(Quantum Break): add initial mod with HDR tonemapping and LUT scaling

### DIFF
--- a/Luma.sln
+++ b/Luma.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Games", "Games", "{02EA681E
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_Template", "Source\Games\_Template\Template.vcxproj", "{08143144-3ABB-D7B3-815C-7A798924E8E6}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Quantum Break", "Source\Games\Quantum Break\Quantum Break.vcxproj", "{3898C29D-83BD-406E-B891-7E2D4BDB34DF}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Unity Engine", "Source\Games\Unity Engine\Unity Engine.vcxproj", "{14E5D475-764C-35B7-7A7F-EA9C910C41BB}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BioShock Series", "Source\Games\BioShock Series\BioShock Series.vcxproj", "{2D83616E-813C-DB05-0623-2E25145C8CCF}"
@@ -137,6 +139,22 @@ Global
 		{08143144-3ABB-D7B3-815C-7A798924E8E6}.Test-Release|Win32.Build.0 = Test-Release|Win32
 		{08143144-3ABB-D7B3-815C-7A798924E8E6}.Test-Release|x64.ActiveCfg = Test-Release|x64
 		{08143144-3ABB-D7B3-815C-7A798924E8E6}.Test-Release|x64.Build.0 = Test-Release|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Debug|Win32.ActiveCfg = Development-Debug|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Debug|Win32.Build.0 = Development-Debug|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Debug|x64.ActiveCfg = Development-Debug|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Debug|x64.Build.0 = Development-Debug|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Release|Win32.ActiveCfg = Development-Release|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Release|Win32.Build.0 = Development-Release|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Release|x64.ActiveCfg = Development-Release|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Development-Release|x64.Build.0 = Development-Release|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Publishing-Release|Win32.ActiveCfg = Publishing-Release|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Publishing-Release|Win32.Build.0 = Publishing-Release|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Publishing-Release|x64.ActiveCfg = Publishing-Release|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Publishing-Release|x64.Build.0 = Publishing-Release|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Test-Release|Win32.ActiveCfg = Test-Release|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Test-Release|Win32.Build.0 = Test-Release|Win32
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Test-Release|x64.ActiveCfg = Test-Release|x64
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF}.Test-Release|x64.Build.0 = Test-Release|x64
 		{14E5D475-764C-35B7-7A7F-EA9C910C41BB}.Development-Debug|Win32.ActiveCfg = Development-Debug|Win32
 		{14E5D475-764C-35B7-7A7F-EA9C910C41BB}.Development-Debug|Win32.Build.0 = Development-Debug|Win32
 		{14E5D475-764C-35B7-7A7F-EA9C910C41BB}.Development-Debug|x64.ActiveCfg = Development-Debug|x64
@@ -584,6 +602,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{3DA928FD-9A18-473E-8D05-F22B96A30197} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{08143144-3ABB-D7B3-815C-7A798924E8E6} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{3898C29D-83BD-406E-B891-7E2D4BDB34DF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{14E5D475-764C-35B7-7A7F-EA9C910C41BB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{2D83616E-813C-DB05-0623-2E25145C8CCF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{A2C1A344-DB26-1518-2783-C64CF97DD969} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}

--- a/Shaders/.clang-format
+++ b/Shaders/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: Microsoft
 IndentWidth: 3
 SpaceBeforeParens: ControlStatements
+ColumnLimit: 0

--- a/Shaders/Quantum Break/debug_tm_0xF0D3CA69.ps_5_0.hlslx
+++ b/Shaders/Quantum Break/debug_tm_0xF0D3CA69.ps_5_0.hlslx
@@ -1,0 +1,486 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:18 2025
+
+struct MaterialData
+{
+   float3 vSpecularColor;          // Offset:    0
+   float fOcclusion;               // Offset:   12
+   float2 vShadowSoftnessRange;    // Offset:   16
+   float2 vScatterWidthRange;      // Offset:   24
+   float2 vTranslucencyDepthRange; // Offset:   32
+   uint uBRDF_uScatterIndex;       // Offset:   40
+   uint uHash;                     // Offset:   44
+};
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer materialid_debug : register(b1)
+{
+   uint g_uMaterialDebugMode : packoffset(c0);
+   bool g_bVisualizeColorClipping : packoffset(c0.y);
+   float2 g_vColorClippingMinMax : packoffset(c0.z);
+}
+
+SamplerState g_sGBuffer1_s : register(s0);
+SamplerState g_sGBuffer2_s : register(s1);
+SamplerState g_sLinearClamp_s : register(s2);
+SamplerState g_sBaseColorCorrectionMap_s : register(s3);
+Texture2D<float4> g_sGBuffer1 : register(t0);
+Texture2D<float4> g_sGBuffer2 : register(t1);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t2);
+Texture2D<float4> g_tTranslucencyKernelSource : register(t3);
+StructuredBuffer<MaterialData> g_sbMaterialData : register(t4);
+Texture2D<float> g_tBrightness : register(t5);
+Texture2D<float4> g_tColorBuffer : register(t6);
+Texture2D<float4> g_tLightBufferInputDiffuse : register(t7);
+Texture2D<float4> g_tLightBufferInputSpecular : register(t8);
+Texture2D<float4> g_tLinearDepthBuffer : register(t9);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0: SV_Position0, out float4 o0: SV_Target0)
+{
+   const float4 icb[] = { { 0, 0, 0, 0 },
+                          { 0, 0, 0.666667, 0 },
+                          { 0, 0.666667, 0, 0 },
+                          { 0, 0.666667, 0.666667, 0 },
+                          { 0.666667, 0, 0, 0 },
+                          { 0.666667, 0, 0.666667, 0 },
+                          { 0.666667, 0.333333, 0, 0 },
+                          { 0.666667, 0.666667, 0.666667, 0 },
+                          { 0.333333, 0.333333, 0.333333, 0 },
+                          { 0.333333, 0.333333, 1.000000, 0 },
+                          { 0.333333, 1.000000, 0.333333, 0 },
+                          { 0.333333, 1.000000, 1.000000, 0 },
+                          { 1.000000, 0.333333, 0.333333, 0 },
+                          { 1.000000, 0.333333, 1.000000, 0 },
+                          { 1.000000, 1.000000, 0.333333, 0 },
+                          { 1.000000, 1.000000, 1.000000, 0 } };
+   float4 r0, r1, r2, r3, r4, r5, r6, r7, r8, r9;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = v0.xy / g_vScreenRes.xy;
+   r0.zw = v0.xy / g_vOutputRes.xy;
+   r1.xyzw = g_sGBuffer1.Sample(g_sGBuffer1_s, r0.zw).xyzw;
+   r2.xyzw = g_sGBuffer2.Sample(g_sGBuffer2_s, r0.zw).xyzw;
+   r3.xyz = g_tLightBufferInputDiffuse.Sample(g_sLinearClamp_s, r0.xy).xyz;
+   r4.xyz = g_tLightBufferInputSpecular.Sample(g_sLinearClamp_s, r0.xy).xyz;
+   r0.z = g_tBrightness.Load(int3(1, 0, 0));
+   r5.xy = float2(-0.5, -0.5) + r0.xy;
+   r5.xy = float2(1.70000005, 0.956250012) * r5.xy;
+   r0.w = dot(r5.xy, r5.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r2.zw = float2(255, 255) * r2.zw;
+   r2.zw = (uint2)r2.zw;
+   r2.z = (uint)r2.z << 8;
+   r2.z = (int)r2.w | (int)r2.z;
+   r5.x = g_sbMaterialData[r2.z].vSpecularColor.x;
+   r5.y = g_sbMaterialData[r2.z].vSpecularColor.y;
+   r5.z = g_sbMaterialData[r2.z].vSpecularColor.z;
+   r5.w = g_sbMaterialData[r2.z].fOcclusion;
+   r6.x = g_sbMaterialData[r2.z].vShadowSoftnessRange.x;
+   r6.y = g_sbMaterialData[r2.z].vShadowSoftnessRange.y;
+   r6.z = g_sbMaterialData[r2.z].vScatterWidthRange.x;
+   r6.w = g_sbMaterialData[r2.z].vScatterWidthRange.y;
+   r7.x = g_sbMaterialData[r2.z].vTranslucencyDepthRange.x;
+   r7.y = g_sbMaterialData[r2.z].vTranslucencyDepthRange.y;
+   r7.z = g_sbMaterialData[r2.z].uBRDF_uScatterIndex;
+   switch (g_uMaterialDebugMode)
+   {
+   case 1:
+      r2.w = (int)r2.z & 0x80000000;
+      r2.z = max((int)-r2.z, (int)r2.z);
+      r2.z = (int)r2.z & 15;
+      r3.w = -(int)r2.z;
+      r2.z = r2.w ? r3.w : r2.z;
+      r8.xyz = icb[r2.z + 0].xyz;
+      break;
+   case 2:
+      r2.z = (int)r7.z & 0x0000ffff;
+      r2.y = r2.z ? 1 : r2.y;
+      r2.yzw = r5.xyz * r2.yyy;
+      r5.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r2.yzw);
+      r9.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r2.yzw;
+      r2.yzw = log2(r2.yzw);
+      r2.yzw = float3(0.416666657, 0.416666657, 0.416666657) * r2.yzw;
+      r2.yzw = exp2(r2.yzw);
+      r2.yzw =
+          r2.yzw * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+      r8.xyz = r5.xyz ? r9.xyz : r2.yzw;
+      break;
+   case 3:
+      r8.xyz = r5.www;
+      break;
+   case 4:
+      r2.y = r6.w + -r6.z;
+      r8.xyz = r2.xxx * r2.yyy + r6.zzz;
+      break;
+   case 5:
+      if (4 == 0)
+         r2.y = 0;
+      else if (4 + 16 < 32)
+      {
+         r2.y = (uint)r7.z << (32 - (4 + 16));
+         r2.y = (uint)r2.y >> (32 - 4);
+      }
+      else
+         r2.y = (uint)r7.z >> 16;
+      r8.xyz = icb[r2.y + 0].xyz;
+      break;
+   case 6:
+      r2.y = (int)r7.z & 15;
+      r8.xyz = icb[r2.y + 0].xyz;
+      break;
+   case 7:
+      r2.y = r6.y + -r6.x;
+      r8.xyz = r2.xxx * r2.yyy + r6.xxx;
+      break;
+   case 8:
+      r2.y = r7.y + -r7.x;
+      r8.xyz = r2.xxx * r2.yyy + r7.xxx;
+      break;
+   case 9:
+      r2.y = r7.y + -r7.x;
+      r2.x = r2.x * r2.y + r7.x;
+      r2.y = (uint)r7.z >> 16;
+      r5.x = 0.071419999 + r2.x;
+      r2.x = (uint)r2.y;
+      r2.x = 0.5 + r2.x;
+      r5.y = g_fOnePerTranslucencyKernelCount * r2.x;
+      r2.xyz = g_tTranslucencyKernelSource.SampleLevel(g_sLinearClamp_s, r5.xy, 0).xyz;
+      r5.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r2.xyz);
+      r6.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r2.xyz;
+      r2.xyz = log2(r2.xyz);
+      r2.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r2.xyz;
+      r2.xyz = exp2(r2.xyz);
+      r2.xyz =
+          r2.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+      r8.xyz = r5.xyz ? r6.xyz : r2.xyz;
+      break;
+   case 1:
+      r1.w = r1.w * 255 + 0.5;
+      r1.w = (uint)r1.w;
+      r1.w = (int)r1.w & 254;
+      r1.w = (uint)r1.w;
+      r1.w = 0.5 + r1.w;
+      r1.w = (int)r1.w;
+      if (3 == 0)
+         r2.x = 0;
+      else if (3 + 1 < 32)
+      {
+         r2.x = (uint)r1.w << (32 - (3 + 1));
+         r2.x = (uint)r2.x >> (32 - 3);
+      }
+      else
+         r2.x = (uint)r1.w >> 1;
+      r1.w = (uint)r1.w >> 4;
+      r2.xz = (int2)r2.xx;
+      r2.yw = (int2)r1.ww;
+      r2.xyzw = float4(0.5, 0.5, 0.5, 0.5) + r2.xyzw;
+      r2.xyzw = r2.xyzw * float4(0.000490196107, 0.000245098054, 0.000490196107, 0.000245098054) + r1.xyxy;
+      r2.xyzw = r2.xyzw * float4(2, 2, 2, 2) + float4(-1, -1, -1, -1);
+      r2.xyzw = float4(1.29999995, 1.29999995, 2.5999999, 2.5999999) * r2.xyzw;
+      r1.x = dot(r2.xy, r2.xy);
+      r2.xy = float2(1, -1) + r1.xx;
+      r1.xyw = r2.zwy / r2.xxx;
+      r8.xyz = r1.xyw * float3(0.5, 0.5, 0.5) + float3(0.5, 0.5, 0.5);
+      break;
+   case 1:
+      r8.xyz = r1.zzz;
+      break;
+   case 1:
+      r1.xyz = r3.xyz * r0.zzz;
+      r1.xyz = r1.xyz * r0.www;
+      r1.xyz = max(float3(0, 0, 0), r1.xyz);
+      r1.xyz = g_fTonemapKeyValue * r1.xyz;
+      r1.w = dot(r1.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+      r2.x = r1.w * 0.015625 + 1;
+      r1.w = 1 + r1.w;
+      r1.w = r2.x / r1.w;
+      r1.xyz = saturate(r1.xyz * r1.www);
+      r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r1.xyz);
+      r5.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r1.xyz;
+      r1.xyz = log2(r1.xyz);
+      r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+      r1.xyz = exp2(r1.xyz);
+      r1.xyz =
+          r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+      r1.xyz = r2.xyz ? r5.xyz : r1.xyz;
+      r1.z = 32 * r1.z;
+      r1.x = r1.x * 0.03125 + 0.00048828125;
+      r1.x = max(0.00048828125, r1.x);
+      r1.y = 0.015625 + r1.y;
+      r1.y = max(0.015625, r1.y);
+      r2.z = min(0.984375, r1.y);
+      r1.y = floor(r1.z);
+      r1.y = 0.03125 * r1.y;
+      r1.y = max(0, r1.y);
+      r1.xy = min(float2(0.0307617188, 0.96875), r1.xy);
+      r2.y = r1.x + r1.y;
+      r5.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r2.yz).xyz;
+      r1.y = ceil(r1.z);
+      r1.y = 0.03125 * r1.y;
+      r1.y = max(0, r1.y);
+      r1.y = min(0.96875, r1.y);
+      r2.x = r1.x + r1.y;
+      r1.xyw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r2.xz).xyz;
+      r1.z = frac(r1.z);
+      r1.xyw = r1.xyw + -r5.xyz;
+      r1.xyz = r1.zzz * r1.xyw + r5.xyz;
+      r8.xyz = g_fTonemapBrightness * r1.xyz;
+      break;
+   case 1:
+      r1.xyz = r4.xyz * r0.zzz;
+      r1.xyz = r1.xyz * r0.www;
+      r1.xyz = max(float3(0, 0, 0), r1.xyz);
+      r1.xyz = g_fTonemapKeyValue * r1.xyz;
+      r1.w = dot(r1.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+      r2.x = r1.w * 0.015625 + 1;
+      r1.w = 1 + r1.w;
+      r1.w = r2.x / r1.w;
+      r1.xyz = saturate(r1.xyz * r1.www);
+      r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r1.xyz);
+      r5.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r1.xyz;
+      r1.xyz = log2(r1.xyz);
+      r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+      r1.xyz = exp2(r1.xyz);
+      r1.xyz =
+          r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+      r1.xyz = r2.xyz ? r5.xyz : r1.xyz;
+      r1.z = 32 * r1.z;
+      r1.x = r1.x * 0.03125 + 0.00048828125;
+      r1.x = max(0.00048828125, r1.x);
+      r1.y = 0.015625 + r1.y;
+      r1.y = max(0.015625, r1.y);
+      r2.z = min(0.984375, r1.y);
+      r1.y = floor(r1.z);
+      r1.y = 0.03125 * r1.y;
+      r1.y = max(0, r1.y);
+      r1.xy = min(float2(0.0307617188, 0.96875), r1.xy);
+      r2.y = r1.x + r1.y;
+      r5.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r2.yz).xyz;
+      r1.y = ceil(r1.z);
+      r1.y = 0.03125 * r1.y;
+      r1.y = max(0, r1.y);
+      r1.y = min(0.96875, r1.y);
+      r2.x = r1.x + r1.y;
+      r1.xyw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r2.xz).xyz;
+      r1.z = frac(r1.z);
+      r1.xyw = r1.xyw + -r5.xyz;
+      r1.xyz = r1.zzz * r1.xyw + r5.xyz;
+      r8.xyz = g_fTonemapBrightness * r1.xyz;
+      break;
+   case 1:
+      r1.xyz = r4.xyz + r3.xyz;
+      r1.xyz = r1.xyz * r0.zzz;
+      r1.xyz = r1.xyz * r0.www;
+      r1.xyz = max(float3(0, 0, 0), r1.xyz);
+      r1.xyz = g_fTonemapKeyValue * r1.xyz;
+      r0.z = dot(r1.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+      r0.w = r0.z * 0.015625 + 1;
+      r0.z = 1 + r0.z;
+      r0.z = r0.w / r0.z;
+      r1.xyz = saturate(r1.xyz * r0.zzz);
+      r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r1.xyz);
+      r3.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r1.xyz;
+      r1.xyz = log2(r1.xyz);
+      r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+      r1.xyz = exp2(r1.xyz);
+      r1.xyz =
+          r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+      r1.xyz = r2.xyz ? r3.xyz : r1.xyz;
+      r0.z = 32 * r1.z;
+      r0.w = r1.x * 0.03125 + 0.00048828125;
+      r0.w = max(0.00048828125, r0.w);
+      r0.w = min(0.0307617188, r0.w);
+      r1.x = 0.015625 + r1.y;
+      r1.x = max(0.015625, r1.x);
+      r1.w = floor(r0.z);
+      r1.w = 0.03125 * r1.w;
+      r1.w = max(0, r1.w);
+      r1.zw = min(float2(0.984375, 0.96875), r1.xw);
+      r1.y = r1.w + r0.w;
+      r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+      r1.y = ceil(r0.z);
+      r1.y = 0.03125 * r1.y;
+      r1.y = max(0, r1.y);
+      r1.y = min(0.96875, r1.y);
+      r1.x = r1.y + r0.w;
+      r1.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+      r0.z = frac(r0.z);
+      r1.xyz = r1.xyz + -r2.xyz;
+      r1.xyz = r0.zzz * r1.xyz + r2.xyz;
+      r8.xyz = g_fTonemapBrightness * r1.xyz;
+      break;
+   case 1:
+      r0.z = g_tLinearDepthBuffer.Sample(g_sLinearClamp_s, r0.xy).x;
+      r0.z = 0.00200000009 * r0.z;
+      r0.z = rsqrt(abs(r0.z));
+      r8.x = 1 / r0.z;
+      r8.yz = float2(0, 0);
+      break;
+   default:
+      r8.xyz = g_tColorBuffer.Sample(g_sLinearClamp_s, r0.xy).xyz;
+      break;
+   }
+   r0.x = dot(r8.xyz, float3(0.308600008, 0.609399974, 0.0820000023));
+   r0.y = cmp(r0.x < g_vColorClippingMinMax.x);
+   r0.yzw = r0.yyy ? float3(1, 0, 0) : r8.xyz;
+   r0.x = cmp(g_vColorClippingMinMax.y < r0.x);
+   r0.xyz = r0.xxx ? float3(0, 0, 1) : r0.yzw;
+   o0.xyz = g_bVisualizeColorClipping ? r0.xyz : r8.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/postfx_0x99274617.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/postfx_0x99274617.ps_5_0.hlsl
@@ -1,0 +1,232 @@
+#include "./quantum_break_common.hlsli"
+
+// clang-format off
+cbuffer cb_update_1 : register(b0) {
+  float2 g_vScreenRes : packoffset(c0);
+  float2 g_vInvScreenRes : packoffset(c0.z);
+  float2 g_vOutputRes : packoffset(c1);
+  float2 g_vInvOutputRes : packoffset(c1.z);
+  float4x4 g_mWorldToView : packoffset(c2);
+  float4x4 g_mViewToWorld : packoffset(c6);
+  float4x4 g_mViewToClip : packoffset(c10);
+  float4x4 g_mClipToView : packoffset(c14);
+  float4x4 g_mWorldToClip : packoffset(c18);
+  float4x4 g_mClipToWorld : packoffset(c22);
+  float4x4 g_mClipToPreviousClip : packoffset(c26);
+  float4x4 g_mViewToPreviousClip : packoffset(c30);
+  float4x4 g_mPreviousViewToView : packoffset(c34);
+  float4x4 g_mPreviousWorldToClip : packoffset(c38);
+  float4x4 g_mPreviousViewToClip : packoffset(c42);
+  float4 g_vViewPoint : packoffset(c46);
+  float g_fInvNear : packoffset(c47);
+  float g_fSimulationTime : packoffset(c47.y);
+  float g_fSimulationTimeDelta : packoffset(c47.z);
+  float g_fSimulationTimeStep : packoffset(c47.w);
+  uint g_uTemporalFrame : packoffset(c48);
+  uint g_uCurrentFrame : packoffset(c48.y);
+
+  struct {
+    float4 vSunDir;
+    float4 vSunE;
+    float4 vExtinction;
+    float4 vRayleigh;
+    float4 vMie;
+    float4 vSchlickConstants;
+    float4 vFog;
+  } g_atmosphere : packoffset(c49);
+
+  float3 g_vFogColor : packoffset(c56);
+  float3 g_vFogColorOpposite : packoffset(c57);
+  float g_fFogExp : packoffset(c57.w);
+  float g_fFogGroundDensityAtViewer : packoffset(c58);
+  float g_fFogGroundHeight : packoffset(c58.y);
+  float g_fFogGroundFalloff : packoffset(c58.z);
+  float g_fFogGroundDensity : packoffset(c58.w);
+  float2 g_vFogGroundDensityMapRange : packoffset(c59);
+  float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+  uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+  float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+  float4 g_fTileDepthRanges[5] : packoffset(c66);
+  float2 g_vDepthTileResolve : packoffset(c71);
+  uint g_uDepthTileCount : packoffset(c71.z);
+  uint2 g_vTileResolution : packoffset(c72);
+  uint3 g_vTileWidthHeightDepth : packoffset(c73);
+  float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+  float2 g_vTileDepthNearFar : packoffset(c74.z);
+  uint g_uMaxPointLightsPerTile : packoffset(c75);
+  uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+  uint g_uAmbientLightTotalCount : packoffset(c75.z);
+  float g_fAmbientEnvIntensity : packoffset(c75.w);
+  float g_fAmbientSkyIntensity : packoffset(c76);
+  float g_fAmbientLocalIntensity : packoffset(c76.y);
+  uint g_uPointLightTotalCount : packoffset(c76.z);
+  uint g_uSpotLightTotalCount : packoffset(c76.w);
+  uint g_uSunLightTotalCount : packoffset(c77);
+  uint g_uAmbientLightEnabled : packoffset(c77.y);
+  float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+  float g_fEnvReflectionMipCount : packoffset(c77.w);
+  float g_fInnerRadius : packoffset(c78);
+  float g_fOuterRadius : packoffset(c78.y);
+  float g_fFadeout : packoffset(c78.z);
+  float4 g_vPlayerViewPosition : packoffset(c79);
+  float4 g_vPlayerWorldPosition : packoffset(c80);
+  float3 g_vDistortionUpInView : packoffset(c81);
+  float3 g_vDistortionUpInWorld : packoffset(c82);
+  float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+  float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+  float g_fFlakeSpawnThreshold : packoffset(c91);
+  float g_fFlakeSpawnProbability : packoffset(c91.y);
+  float g_fParticleLifetime : packoffset(c91.z);
+  float g_fParticleLifetimeDeviation : packoffset(c91.w);
+  float3 g_vParticleVelocity : packoffset(c92);
+  float g_fParticleSpeedDeviation : packoffset(c92.w);
+  float g_fParticleDirectionDeviation : packoffset(c93);
+  float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+  float g_fParticleEmissionFrequency : packoffset(c94);
+  uint4 g_vRandomInts : packoffset(c95);
+  float2 g_vHalfResolutionJitter : packoffset(c96);
+  float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+  float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+  float g_fEnvironmentMapColSize : packoffset(c97);
+  float g_fEnvironmentMapRowSize : packoffset(c97.y);
+  float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+  uint4 g_vVolumeLightDimensions : packoffset(c98);
+  float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+  float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+  float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+  float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+  float3 g_vVolumeLightDepthResolve : packoffset(c103);
+  float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+  float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+  float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+  float g_fVolumeLightKernelWidth : packoffset(c105.z);
+  float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+  float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+  float4x4 g_mTessellationWorldToClip : packoffset(c107);
+  float3 g_fTessellationViewPosition : packoffset(c111);
+  float3 g_fTessellationViewDirection : packoffset(c112);
+  float g_fTessellationViewToClip11 : packoffset(c112.w);
+  float g_fVignetteExp : packoffset(c113);
+  float g_fTonemapKeyValue : packoffset(c113.y);
+  float g_fTonemapGamma : packoffset(c113.z);
+  float g_fTonemapSaturation : packoffset(c113.w);
+  float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+  float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+  float2 g_vTonemapLevels : packoffset(c116);
+  float g_fTonemapNoiseIntensity : packoffset(c116.z);
+  int2 g_vTonemapNoiseOffset : packoffset(c117);
+  float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+  float g_fTonemapBrightness : packoffset(c118);
+  bool g_bUseWBOIT : packoffset(c118.y);
+  float2 g_vViewportRes : packoffset(c118.z);
+  float2 g_vInvViewportRes : packoffset(c119);
+  float2 g_vViewportOffset : packoffset(c119.z);
+  float2 g_vShadowMapRes : packoffset(c120);
+  float2 g_vShadowMapVSMRes : packoffset(c120.z);
+  float2 g_vJitterOffset : packoffset(c121);
+  int2 g_vSnapOffset : packoffset(c121.z);
+  float g_fGIVolumeIntensity : packoffset(c122);
+  float4 g_vScreenToView : packoffset(c123);
+  float4x4 g_mViewToPreviousScreen : packoffset(c124);
+  float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+  float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+  float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+  float g_fViewVolumeDebugDepth : packoffset(c129.w);
+  float3 g_fViewVolumeDebugDirection : packoffset(c130);
+  float3 g_fViewVolumeDebugPosition : packoffset(c131);
+  float3 g_vSunDirVS : packoffset(c132);
+  float3 g_vSunRightVS : packoffset(c133);
+  float3 g_vSunUpVS : packoffset(c134);
+  float3 g_vSunColor : packoffset(c135);
+};
+// clang-format on
+
+cbuffer ssaa : register(b1)
+{
+   float4x4 g_mSSAAClipToPreviousClip[3] : packoffset(c0);
+   float2 g_vSSAAJitterOffset[4] : packoffset(c12);
+   float2 g_vTAASourceRes : packoffset(c15.z);
+   float2 g_vInvTAASourceRes : packoffset(c16);
+};
+
+SamplerState g_sLinearClamp : register(s0);
+Texture2D<float4> g_tClipDepth : register(t0);
+Texture2D<float4> g_sFilmGrain : register(t1);
+Texture2D<float4> g_tColor : register(t2);
+Texture2D<float4> g_tPreviousColor[3] : register(t3);
+
+static float2 gl_FragCoord;
+static float gl_FragDepth;
+static float3 SV_Target;
+
+struct SPIRV_Cross_Input
+{
+   noperspective float4 gl_FragCoord : SV_Position;
+};
+
+struct SPIRV_Cross_Output
+{
+   float3 SV_Target : SV_Target0;
+   float gl_FragDepth : SV_Depth;
+};
+
+int cvt_f32_i32(float v)
+{
+   uint abs_bits = asuint(v) & 0x7fffffffu;
+   bool is_nan = abs_bits > 0x7f800000u;
+   return is_nan ? 0 : ((v < (-2147483648.0f)) ? int(0x80000000) : ((v > 2147483520.0f) ? 2147483647 : int(v)));
+}
+
+void frag_main()
+{
+   float4 _104 = g_sFilmGrain.Load(
+       int3(uint2(uint(cvt_f32_i32(float(uint(cvt_f32_i32(gl_FragCoord.x + float(g_vTonemapNoiseOffset.x)) & 511)))),
+                  uint(cvt_f32_i32(float(uint(cvt_f32_i32(gl_FragCoord.y + float(g_vTonemapNoiseOffset.y)) & 511))))),
+            0u));
+
+   float _111 = (CUSTOM_GRAIN_TYPE == 0.f) ? g_fTonemapNoiseIntensity : 0.f;
+
+   float _113 = (1.0f - _111) * 0.5f;
+   float _117 = (_104.x * _111) + _113;
+   float _118 = _113 + (_104.y * _111);
+   float _119 = _113 + (_104.z * _111);
+   float _124 = g_vInvScreenRes.x;
+   float _125 = g_vInvScreenRes.y;
+   float4 _140 =
+       g_tPreviousColor[0].Sample(g_sLinearClamp, float2(mad(gl_FragCoord.x, _124, g_vSSAAJitterOffset[1].x),
+                                                         mad(gl_FragCoord.y, _125, g_vSSAAJitterOffset[1].y)));
+   float4 _153 =
+       g_tPreviousColor[1].Sample(g_sLinearClamp, float2(mad(gl_FragCoord.x, _124, g_vSSAAJitterOffset[2].x),
+                                                         mad(gl_FragCoord.y, _125, g_vSSAAJitterOffset[2].y)));
+   float4 _169 =
+       g_tPreviousColor[2].Sample(g_sLinearClamp, float2(mad(gl_FragCoord.x, _124, g_vSSAAJitterOffset[3].x),
+                                                         mad(gl_FragCoord.y, _125, g_vSSAAJitterOffset[3].y)));
+   float _180 = mad(gl_FragCoord.x, _124, g_vSSAAJitterOffset[0].x);
+   float _181 = mad(gl_FragCoord.y, _125, g_vSSAAJitterOffset[0].y);
+   float2 _183 = float2(_180, _181);
+   float4 _185 = g_tColor.Sample(g_sLinearClamp, _183);
+   float4 _191 = g_tClipDepth.Sample(g_sLinearClamp, _183);
+   float _192 = _191.x;
+   gl_FragDepth = _192;
+   float _193 = ((_140.x + _153.x) + _169.x) + _185.x;
+   float _194 = _185.y + (_169.y + (_140.y + _153.y));
+   float _195 = _185.z + (_169.z + (_140.z + _153.z));
+   SV_Target.x = (_193 < 2.0f) ? (1.0f - ((mad(_193, -0.25f, 1.0f) * 0.5f) / _117))
+                               : ((_193 * 0.25f) / mad(0.5f - _117, 2.0f, 1.0f));
+   SV_Target.y = (_194 < 2.0f) ? (1.0f - ((mad(_194, -0.25f, 1.0f) * 0.5f) / _118))
+                               : ((_194 * 0.25f) / mad(0.5f - _118, 2.0f, 1.0f));
+   SV_Target.z = (_195 < 2.0f) ? (1.0f - ((mad(_195, -0.25f, 1.0f) * 0.5f) / _119))
+                               : ((_195 * 0.25f) / mad(0.5f - _119, 2.0f, 1.0f));
+
+   SV_Target.rgb = ApplyDisplayMapAndScale(SV_Target.rgb, gl_FragCoord * g_vInvScreenRes);
+}
+
+SPIRV_Cross_Output main(SPIRV_Cross_Input stage_input)
+{
+   gl_FragCoord = stage_input.gl_FragCoord.xy;
+   frag_main();
+   SPIRV_Cross_Output stage_output;
+   stage_output.gl_FragDepth = gl_FragDepth;
+   stage_output.SV_Target = SV_Target;
+   return stage_output;
+}

--- a/Shaders/Quantum Break/quantum_break_common.hlsli
+++ b/Shaders/Quantum Break/quantum_break_common.hlsli
@@ -1,0 +1,50 @@
+#define GCT_DEFAULT 3
+
+#include "../Includes/Common.hlsl"
+
+#define LUT_STRENGTH 1.f
+#define LUT_SCALING 1.f
+#define TONE_MAP_TYPE 1.f
+#define CUSTOM_GRAIN_TYPE 0.f
+
+// f_{p}\left(x\right)=\frac{px}{\sqrt{xx+pp}}
+float Neutwo(float x, float peak)
+{
+   // also written as x * rhypot(x, peak)
+   float p = peak;
+
+   float numerator = p * x;
+   float denominator_squared = mad(x, x, p * p);
+   return numerator * rsqrt(denominator_squared);
+}
+
+float NeutwoComputeMaxChannelScale(float3 color, float peak)
+{
+   float max_channel = max3(abs(color.rgb));
+   float new_max = Neutwo(max_channel, peak);
+   float scale = max_channel != 0 ? (new_max / max_channel) : 1.f;
+   return scale;
+}
+
+float3 NeutwoMaxChannel(float3 color, float peak)
+{
+   return color * NeutwoComputeMaxChannelScale(color, peak);
+}
+
+float3 ApplyDisplayMapAndScale(float3 color, float2 texcoord)
+{
+   if (TONE_MAP_TYPE != 0.f)
+   {
+      color = gamma_sRGB_to_linear(color);
+      color = BT709_To_BT2020(color);
+      color = max(0, color);
+      color = NeutwoMaxChannel(color, PeakWhiteNits / GamePaperWhiteNits);
+      color = BT2020_To_BT709(color);
+      color = linear_to_sRGB_gamma(color);
+   }
+   else
+   {
+      color = saturate(color);
+   }
+   return color;
+}

--- a/Shaders/Quantum Break/shared.h
+++ b/Shaders/Quantum Break/shared.h
@@ -1,0 +1,59 @@
+#ifndef SRC_QUANTUM_BREAK_SHARED_H_
+#define SRC_QUANTUM_BREAK_SHARED_H_
+
+// Must be 32bit aligned
+// Should be 4x32
+struct ShaderInjectData {
+  float tone_map_type;
+  float peak_white_nits;
+  float diffuse_white_nits;
+  float graphics_white_nits;
+  float gamma_correction;
+
+  float tone_map_exposure;
+  float tone_map_highlights;
+  float tone_map_shadows;
+  float tone_map_contrast;
+  float tone_map_saturation;
+  float tone_map_highlight_saturation;
+  float tone_map_dechroma;
+  float tone_map_flare;
+  float scene_grade_strength;
+  float color_grade_scaling;
+
+  float custom_random;
+  float custom_grain_type;
+  float custom_grain_strength;
+};
+
+#ifndef __cplusplus
+cbuffer cb13 : register(b13) {
+  ShaderInjectData shader_injection : packoffset(c0);
+}
+
+#define RENODX_TONE_MAP_TYPE       shader_injection.tone_map_type
+#define RENODX_PEAK_WHITE_NITS     shader_injection.peak_white_nits
+#define RENODX_DIFFUSE_WHITE_NITS  shader_injection.diffuse_white_nits
+#define RENODX_GRAPHICS_WHITE_NITS shader_injection.graphics_white_nits
+#define RENODX_GAMMA_CORRECTION    shader_injection.gamma_correction
+
+#define RENODX_TONE_MAP_EXPOSURE             shader_injection.tone_map_exposure
+#define RENODX_TONE_MAP_HIGHLIGHTS           shader_injection.tone_map_highlights
+#define RENODX_TONE_MAP_SHADOWS              shader_injection.tone_map_shadows
+#define RENODX_TONE_MAP_CONTRAST             shader_injection.tone_map_contrast
+#define RENODX_TONE_MAP_SATURATION           shader_injection.tone_map_saturation
+#define RENODX_TONE_MAP_HIGHLIGHT_SATURATION shader_injection.tone_map_highlight_saturation
+#define RENODX_TONE_MAP_DECHROMA             shader_injection.tone_map_dechroma
+#define RENODX_TONE_MAP_FLARE                shader_injection.tone_map_flare
+#define RENODX_COLOR_GRADE_STRENGTH          shader_injection.scene_grade_strength
+#define RENODX_COLOR_GRADE_SCALING           shader_injection.color_grade_scaling
+
+#define CUSTOM_GRAIN_TYPE     shader_injection.custom_grain_type
+#define CUSTOM_RANDOM         shader_injection.custom_random
+#define CUSTOM_GRAIN_STRENGTH shader_injection.custom_grain_strength
+
+#include "../../shaders/renodx.hlsl"
+
+#endif
+
+#endif  // SRC_QUANTUM_BREAK_SHARED_H_

--- a/Shaders/Quantum Break/tm_0x17F0ECF6.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x17F0ECF6.ps_5_0.hlsl
@@ -1,0 +1,279 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:50 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86CS : register(b1)
+{
+   float g_fBloomIntensityCS : packoffset(c0);
+   float g_fBloomThresholdCS : packoffset(c0.y);
+   float g_fBloomMaxLuminanceCS : packoffset(c0.z);
+   float g_fBloomBlurWeightsCS[5] : packoffset(c1);
+   float g_fBloomWeightsCS[7] : packoffset(c6);
+   float2 g_vScreenResolutionTarget : packoffset(c12.y);
+   float2 g_vBloomCSSourceResolution : packoffset(c13);
+}
+
+cbuffer bloomx86_compose : register(b2)
+{
+   float g_fLensTextureIntensity : packoffset(c0);
+   float4 g_vBloomTextureScaleOffset[7] : packoffset(c1);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+SamplerState g_sLensTexture_s : register(s2);
+Texture2D<float4> g_sLensTexture : register(t0);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t1);
+Texture2D<float> g_tBrightness : register(t2);
+Texture2D<float4> g_tBaseTexture : register(t3);
+Texture2D<float4> g_tBloomTexture_0_ : register(t4);
+Texture2D<float4> g_tBloomTexture_1_ : register(t5);
+Texture2D<float4> g_tBloomTexture_2_ : register(t6);
+Texture2D<float4> g_tBloomTexture_3_ : register(t7);
+Texture2D<float4> g_tBloomTexture_4_ : register(t8);
+Texture2D<float4> g_tBloomTexture_5_ : register(t9);
+Texture2D<float4> g_tBloomTexture_6_ : register(t10);
+Texture2D<float4> g_tObjectHighlightTexture : register(t11);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v1.xy;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[1].xy + g_vBloomTextureScaleOffset[1].zw;
+   r1.xyz = g_tBloomTexture_1_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = g_fBloomWeightsCS[1] * r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[0].xy + g_vBloomTextureScaleOffset[0].zw;
+   r2.xyz = g_tBloomTexture_0_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[0] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[2].xy + g_vBloomTextureScaleOffset[2].zw;
+   r2.xyz = g_tBloomTexture_2_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[2] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[3].xy + g_vBloomTextureScaleOffset[3].zw;
+   r2.xyz = g_tBloomTexture_3_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[3] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[4].xy + g_vBloomTextureScaleOffset[4].zw;
+   r2.xyz = g_tBloomTexture_4_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[4] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[5].xy + g_vBloomTextureScaleOffset[5].zw;
+   r0.xy = r0.xy * g_vBloomTextureScaleOffset[6].xy + g_vBloomTextureScaleOffset[6].zw;
+   r2.xyz = g_tBloomTexture_6_.SampleLevel(g_sLinearClamp_s, r0.xy, 0).xyz;
+   r0.xyz = g_tBloomTexture_5_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r0.xyz = r0.xyz * g_fBloomWeightsCS[5] + r1.xyz;
+   r0.xyz = r2.xyz * g_fBloomWeightsCS[6] + r0.xyz;
+   r0.w = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).x;
+   r0.w = r0.w + r0.w;
+   r1.xyz = r0.xyz * r0.www + -r0.xyz;
+   r0.xyz = g_fLensTextureIntensity * r1.xyz + r0.xyz;
+   r1.xyz = g_tBaseTexture.SampleLevel(g_sLinearClamp_s, v0.xy, 0).xyz;
+   r0.xyz = r1.xyz + r0.xyz;
+   r0.w = g_tBrightness.Load(int3(1, 0, 0));
+   r0.xyz = r0.xyz * r0.www;
+   r1.xy = float2(-0.5, -0.5) + v0.xy;
+   r1.xy = float2(1.70000005, 0.956250012) * r1.xy;
+   r0.w = dot(r1.xy, r1.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r0.xyz = r0.xyz * r0.www;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   r0.xyz = g_fTonemapBrightness * r0.xyz;
+   r1.xy = (uint2)v1.xy;
+   r1.zw = float2(0, 0);
+   r1.xyzw = g_tObjectHighlightTexture.Load(r1.xyz).xyzw;
+   o0.xyz = r0.xyz * r1.www + r1.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x3146CDE1.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x3146CDE1.ps_5_0.hlsl
@@ -1,0 +1,237 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:52 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86_compose : register(b1)
+{
+   float2 g_vBloomedImageRes : packoffset(c0);
+   float g_fLensTextureIntensity : packoffset(c0.z);
+}
+
+SamplerState g_sBaseColorCorrectionMap_s : register(s0);
+SamplerState g_sOriginalImage_s : register(s1);
+SamplerState g_sBloomedImage_s : register(s2);
+SamplerState g_sLensTexture_s : register(s3);
+Texture2D<float4> g_sOriginalImage : register(t0);
+Texture2D<float4> g_sBloomedImage : register(t1);
+Texture2D<float4> g_sLensTexture : register(t2);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t3);
+Texture2D<float> g_tBrightness : register(t4);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v0.xy;
+   r0.xy = float2(1.70000005, 0.956250012) * r0.xy;
+   r0.x = dot(r0.xy, r0.xy);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r1.xyzw = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).xyzw;
+   r2.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, v0.xy).xyzw;
+   r1.xyzw = r2.xyzw * r1.xyzw;
+   r1.xyzw = r1.xyzw * float4(2, 2, 2, 2) + -r2.xyzw;
+   r1.xyzw = g_fLensTextureIntensity * r1.xyzw + r2.xyzw;
+   r2.xyzw = g_sOriginalImage.Sample(g_sOriginalImage_s, v0.xy).xyzw;
+   r1.xyzw = r2.xyzw + r1.xyzw;
+   r0.y = g_tBrightness.Load(int3(1, 0, 0));
+   r0.yzw = r1.xyz * r0.yyy;
+   o0.w = r1.w;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x49FE8ACE.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x49FE8ACE.ps_5_0.hlsl
@@ -1,0 +1,221 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:55 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t0);
+Texture2D<float> g_tBrightness : register(t1);
+Texture2D<float4> g_tBaseTexture : register(t2);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v0.xy;
+   r0.xy = float2(1.70000005, 0.956250012) * r0.xy;
+   r0.x = dot(r0.xy, r0.xy);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r0.yzw = g_tBaseTexture.SampleLevel(g_sLinearClamp_s, v0.xy, 0).xyz;
+   r1.x = g_tBrightness.Load(int3(1, 0, 0));
+   r0.yzw = r1.xxx * r0.yzw;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x5BF8A559.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x5BF8A559.ps_5_0.hlsl
@@ -1,0 +1,226 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:56 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t0);
+Texture2D<float> g_tBrightness : register(t1);
+Texture2D<float4> g_tBaseTexture : register(t2);
+Texture2D<float4> g_tObjectHighlightTexture : register(t3);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v0.xy;
+   r0.xy = float2(1.70000005, 0.956250012) * r0.xy;
+   r0.x = dot(r0.xy, r0.xy);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r0.yzw = g_tBaseTexture.SampleLevel(g_sLinearClamp_s, v0.xy, 0).xyz;
+   r1.x = g_tBrightness.Load(int3(1, 0, 0));
+   r0.yzw = r1.xxx * r0.yzw;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   r0.xyz = g_fTonemapBrightness * r0.xyz;
+   r1.xy = (uint2)v1.xy;
+   r1.zw = float2(0, 0);
+   r1.xyzw = g_tObjectHighlightTexture.Load(r1.xyz).xyzw;
+   o0.xyz = r0.xyz * r1.www + r1.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x5CA5E922.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x5CA5E922.ps_5_0.hlsl
@@ -1,0 +1,246 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:57 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t0);
+Texture2D<float> g_tBrightness : register(t1);
+Texture3D<float4> g_tViewVolumeLighting_0_ : register(t2);
+Texture3D<float4> g_tViewVolumeLighting_1_ : register(t3);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float4 v0: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2, r3;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = v0.xy + v0.xy;
+   r0.zw = cmp(g_vScreenRes.xy < r0.xy);
+   if (r0.z != 0)
+      discard;
+   if (r0.w != 0)
+      discard;
+   r0.z = 1 + -abs(g_fViewVolumeDebugDirection.z);
+   r1.yzw = float3(0.5, 0.5, 0.5) * r0.zzz;
+   r1.x = 1;
+   r2.xy = g_vInvScreenRes.xy * r0.xy;
+   r0.xy = r0.xy * g_vInvScreenRes.xy + float2(-0.5, -0.5);
+   r0.xy = float2(1.70000005, 0.956250012) * r0.xy;
+   r0.x = dot(r0.xy, r0.xy);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r2.z = g_fViewVolumeDebugDepth;
+   r3.xyzw = g_tViewVolumeLighting_1_.SampleLevel(g_sLinearClamp_s, r2.xyz, 0).xyzw;
+   r0.yzw = g_tViewVolumeLighting_0_.SampleLevel(g_sLinearClamp_s, r2.xyz, 0).xyz;
+   r1.xyzw = r3.xyzw * r1.xyzw;
+   r2.x = dot(r1.xyzw, r1.xyzw);
+   r2.x = sqrt(r2.x);
+   r2.y = cmp(r2.x != 0.000000);
+   r2.x = rcp(r2.x);
+   r2.x = r2.y ? r2.x : 0;
+   r1.xyzw = r2.xxxx * r1.xyzw;
+   r2.x = 1;
+   r2.yzw = g_fViewVolumeDebugDirection.xyz;
+   r1.x = dot(r1.xyzw, r2.xyzw);
+   r1.x = max(0, r1.x);
+   r0.yzw = r1.xxx * r0.yzw;
+   r1.x = g_tBrightness.Load(int3(1, 0, 0));
+   r0.yzw = r1.xxx * r0.yzw;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x6B82C898.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x6B82C898.ps_5_0.hlsl
@@ -1,0 +1,275 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:59 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86CS : register(b1)
+{
+   float g_fBloomIntensityCS : packoffset(c0);
+   float g_fBloomThresholdCS : packoffset(c0.y);
+   float g_fBloomMaxLuminanceCS : packoffset(c0.z);
+   float g_fBloomBlurWeightsCS[5] : packoffset(c1);
+   float g_fBloomWeightsCS[7] : packoffset(c6);
+   float2 g_vScreenResolutionTarget : packoffset(c12.y);
+   float2 g_vBloomCSSourceResolution : packoffset(c13);
+}
+
+cbuffer bloomx86_compose : register(b2)
+{
+   float g_fLensTextureIntensity : packoffset(c0);
+   float4 g_vBloomTextureScaleOffset[7] : packoffset(c1);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+SamplerState g_sLensTexture_s : register(s2);
+Texture2D<float4> g_sLensTexture : register(t0);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t1);
+Texture2D<float> g_tBrightness : register(t2);
+Texture2D<float4> g_tBaseTexture : register(t3);
+Texture2D<float4> g_tBloomTexture_0_ : register(t4);
+Texture2D<float4> g_tBloomTexture_1_ : register(t5);
+Texture2D<float4> g_tBloomTexture_2_ : register(t6);
+Texture2D<float4> g_tBloomTexture_3_ : register(t7);
+Texture2D<float4> g_tBloomTexture_4_ : register(t8);
+Texture2D<float4> g_tBloomTexture_5_ : register(t9);
+Texture2D<float4> g_tObjectHighlightTexture : register(t11);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v1.xy;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[1].xy + g_vBloomTextureScaleOffset[1].zw;
+   r1.xyz = g_tBloomTexture_1_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = g_fBloomWeightsCS[1] * r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[0].xy + g_vBloomTextureScaleOffset[0].zw;
+   r2.xyz = g_tBloomTexture_0_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[0] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[2].xy + g_vBloomTextureScaleOffset[2].zw;
+   r2.xyz = g_tBloomTexture_2_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[2] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[3].xy + g_vBloomTextureScaleOffset[3].zw;
+   r2.xyz = g_tBloomTexture_3_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[3] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[4].xy + g_vBloomTextureScaleOffset[4].zw;
+   r0.xy = r0.xy * g_vBloomTextureScaleOffset[5].xy + g_vBloomTextureScaleOffset[5].zw;
+   r2.xyz = g_tBloomTexture_5_.SampleLevel(g_sLinearClamp_s, r0.xy, 0).xyz;
+   r0.xyz = g_tBloomTexture_4_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r0.xyz = r0.xyz * g_fBloomWeightsCS[4] + r1.xyz;
+   r0.xyz = r2.xyz * g_fBloomWeightsCS[5] + r0.xyz;
+   r0.w = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).x;
+   r0.w = r0.w + r0.w;
+   r1.xyz = r0.xyz * r0.www + -r0.xyz;
+   r0.xyz = g_fLensTextureIntensity * r1.xyz + r0.xyz;
+   r1.xyz = g_tBaseTexture.SampleLevel(g_sLinearClamp_s, v0.xy, 0).xyz;
+   r0.xyz = r1.xyz + r0.xyz;
+   r0.w = g_tBrightness.Load(int3(1, 0, 0));
+   r0.xyz = r0.xyz * r0.www;
+   r1.xy = float2(-0.5, -0.5) + v0.xy;
+   r1.xy = float2(1.70000005, 0.956250012) * r1.xy;
+   r0.w = dot(r1.xy, r1.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r0.xyz = r0.xyz * r0.www;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   r0.xyz = g_fTonemapBrightness * r0.xyz;
+   r1.xy = (uint2)v1.xy;
+   r1.zw = float2(0, 0);
+   r1.xyzw = g_tObjectHighlightTexture.Load(r1.xyz).xyzw;
+   o0.xyz = r0.xyz * r1.www + r1.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x6E15B1F2.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x6E15B1F2.ps_5_0.hlsl
@@ -1,0 +1,230 @@
+
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:59 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+SamplerState g_sBaseColorCorrectionMap_s : register(s0);
+SamplerState g_sOriginalImage_s : register(s1);
+Texture2D<float4> g_sOriginalImage : register(t0);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t1);
+Texture2D<float> g_tBrightness : register(t2);
+Texture2D<float4> g_tObjectHighlightTexture : register(t3);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v0.xy;
+   r0.zw = float2(1.70000005, 0.956250012) * r0.xy;
+   r1.xyzw = r0.xyxy * g_vTonemapChromaticAberration.xxyy + float4(0.5, 0.5, 0.5, 0.5);
+   r0.x = dot(r0.zw, r0.zw);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r2.x = g_sOriginalImage.Sample(g_sOriginalImage_s, r1.xy).x;
+   r2.z = g_sOriginalImage.Sample(g_sOriginalImage_s, r1.zw).z;
+   r0.y = g_tBrightness.Load(int3(1, 0, 0));
+   r2.yw = g_sOriginalImage.Sample(g_sOriginalImage_s, v0.xy).yw;
+   o0.w = r2.w;
+   r0.yzw = r2.xyz * r0.yyy;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   r0.xyz = g_fTonemapBrightness * r0.xyz;
+   r1.xy = (uint2)v1.xy;
+   r1.zw = float2(0, 0);
+   r1.xyzw = g_tObjectHighlightTexture.Load(r1.xyz).xyzw;
+   o0.xyz = r0.xyz * r1.www + r1.xyz;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0x715E2637.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0x715E2637.ps_5_0.hlsl
@@ -1,0 +1,260 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:00 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86_compose : register(b1)
+{
+   float2 g_vBloomedImageRes : packoffset(c0);
+   float g_fLensTextureIntensity : packoffset(c0.z);
+}
+
+SamplerState g_sBaseColorCorrectionMap_s : register(s0);
+SamplerState g_sOriginalImage_s : register(s1);
+SamplerState g_sBloomedImage_s : register(s2);
+SamplerState g_sLensTexture_s : register(s3);
+Texture2D<float4> g_sOriginalImage : register(t0);
+Texture2D<float4> g_sBloomedImage : register(t1);
+Texture2D<float4> g_sLensTexture : register(t2);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t3);
+Texture2D<float> g_tBrightness : register(t4);
+Texture2D<float4> g_tObjectHighlightTexture : register(t5);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2, r3, r4, r5;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(0.5, 0.5) / g_vBloomedImageRes.xy;
+   r0.zw = -r0.yx;
+   r1.xyzw = v0.xyxy + r0.xzwy;
+   r2.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r1.xy).xyzw;
+   r1.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r1.zw).xyzw;
+   r0.zw = v0.xy * g_vBloomedImageRes.xy + float2(-0.5, -0.5);
+   r0.zw = frac(r0.zw);
+   r3.xy = float2(1, 1) + -r0.wz;
+   r3.zw = r3.xy * r0.zw;
+   r0.z = r0.z * r0.w;
+   r0.w = r3.y * r3.x;
+   r2.xyzw = r3.zzzz * r2.xyzw;
+   r3.xy = v0.xy + -r0.xy;
+   r0.xy = v0.xy + r0.xy;
+   r4.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r0.xy).xyzw;
+   r5.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r3.xy).xyzw;
+   r2.xyzw = r0.wwww * r5.xyzw + r2.xyzw;
+   r1.xyzw = r3.wwww * r1.xyzw + r2.xyzw;
+   r0.xyzw = r0.zzzz * r4.xyzw + r1.xyzw;
+   r1.xyzw = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).xyzw;
+   r1.xyzw = r1.xyzw * r0.xyzw;
+   r1.xyzw = r1.xyzw * float4(2, 2, 2, 2) + -r0.xyzw;
+   r0.xyzw = g_fLensTextureIntensity * r1.xyzw + r0.xyzw;
+   r1.xyzw = g_sOriginalImage.Sample(g_sOriginalImage_s, v0.xy).xyzw;
+   r0.xyzw = r1.xyzw + r0.xyzw;
+   r1.x = g_tBrightness.Load(int3(1, 0, 0));
+   r0.xyz = r1.xxx * r0.xyz;
+   o0.w = r0.w;
+   r1.xy = float2(-0.5, -0.5) + v0.xy;
+   r1.xy = float2(1.70000005, 0.956250012) * r1.xy;
+   r0.w = dot(r1.xy, r1.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r0.xyz = r0.xyz * r0.www;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   r0.xyz = g_fTonemapBrightness * r0.xyz;
+   r1.xy = (uint2)v1.xy;
+   r1.zw = float2(0, 0);
+   r1.xyzw = g_tObjectHighlightTexture.Load(r1.xyz).xyzw;
+   o0.xyz = r0.xyz * r1.www + r1.xyz;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0xACCF5A94.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0xACCF5A94.ps_5_0.hlsl
@@ -1,0 +1,243 @@
+
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:07 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86_compose : register(b1)
+{
+   float2 g_vBloomedImageRes : packoffset(c0);
+   float g_fLensTextureIntensity : packoffset(c0.z);
+}
+
+SamplerState g_sBaseColorCorrectionMap_s : register(s0);
+SamplerState g_sOriginalImage_s : register(s1);
+SamplerState g_sBloomedImage_s : register(s2);
+SamplerState g_sLensTexture_s : register(s3);
+Texture2D<float4> g_sOriginalImage : register(t0);
+Texture2D<float4> g_sBloomedImage : register(t1);
+Texture2D<float4> g_sLensTexture : register(t2);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t3);
+Texture2D<float> g_tBrightness : register(t4);
+Texture2D<float4> g_tObjectHighlightTexture : register(t5);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v0.xy;
+   r0.xy = float2(1.70000005, 0.956250012) * r0.xy;
+   r0.x = dot(r0.xy, r0.xy);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r1.xyzw = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).xyzw;
+   r2.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, v0.xy).xyzw;
+   r1.xyzw = r2.xyzw * r1.xyzw;
+   r1.xyzw = r1.xyzw * float4(2, 2, 2, 2) + -r2.xyzw;
+   r1.xyzw = g_fLensTextureIntensity * r1.xyzw + r2.xyzw;
+   r2.xyzw = g_sOriginalImage.Sample(g_sOriginalImage_s, v0.xy).xyzw;
+   r1.xyzw = r2.xyzw + r1.xyzw;
+   r0.y = g_tBrightness.Load(int3(1, 0, 0));
+   r0.yzw = r1.xyz * r0.yyy;
+   o0.w = r1.w;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   r0.xyz = g_fTonemapBrightness * r0.xyz;
+   r1.xy = (uint2)v1.xy;
+   r1.zw = float2(0, 0);
+   r1.xyzw = g_tObjectHighlightTexture.Load(r1.xyz).xyzw;
+   o0.xyz = r0.xyz * r1.www + r1.xyz;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0xE18D9E06.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0xE18D9E06.ps_5_0.hlsl
@@ -1,0 +1,274 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:14 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86CS : register(b1)
+{
+   float g_fBloomIntensityCS : packoffset(c0);
+   float g_fBloomThresholdCS : packoffset(c0.y);
+   float g_fBloomMaxLuminanceCS : packoffset(c0.z);
+   float g_fBloomBlurWeightsCS[5] : packoffset(c1);
+   float g_fBloomWeightsCS[7] : packoffset(c6);
+   float2 g_vScreenResolutionTarget : packoffset(c12.y);
+   float2 g_vBloomCSSourceResolution : packoffset(c13);
+}
+
+cbuffer bloomx86_compose : register(b2)
+{
+   float g_fLensTextureIntensity : packoffset(c0);
+   float4 g_vBloomTextureScaleOffset[7] : packoffset(c1);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+SamplerState g_sLensTexture_s : register(s2);
+Texture2D<float4> g_sLensTexture : register(t0);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t1);
+Texture2D<float> g_tBrightness : register(t2);
+Texture2D<float4> g_tBaseTexture : register(t3);
+Texture2D<float4> g_tBloomTexture_0_ : register(t4);
+Texture2D<float4> g_tBloomTexture_1_ : register(t5);
+Texture2D<float4> g_tBloomTexture_2_ : register(t6);
+Texture2D<float4> g_tBloomTexture_3_ : register(t7);
+Texture2D<float4> g_tBloomTexture_4_ : register(t8);
+Texture2D<float4> g_tBloomTexture_5_ : register(t9);
+Texture2D<float4> g_tBloomTexture_6_ : register(t10);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v1.xy;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[1].xy + g_vBloomTextureScaleOffset[1].zw;
+   r1.xyz = g_tBloomTexture_1_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = g_fBloomWeightsCS[1] * r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[0].xy + g_vBloomTextureScaleOffset[0].zw;
+   r2.xyz = g_tBloomTexture_0_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[0] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[2].xy + g_vBloomTextureScaleOffset[2].zw;
+   r2.xyz = g_tBloomTexture_2_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[2] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[3].xy + g_vBloomTextureScaleOffset[3].zw;
+   r2.xyz = g_tBloomTexture_3_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[3] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[4].xy + g_vBloomTextureScaleOffset[4].zw;
+   r2.xyz = g_tBloomTexture_4_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[4] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[5].xy + g_vBloomTextureScaleOffset[5].zw;
+   r0.xy = r0.xy * g_vBloomTextureScaleOffset[6].xy + g_vBloomTextureScaleOffset[6].zw;
+   r2.xyz = g_tBloomTexture_6_.SampleLevel(g_sLinearClamp_s, r0.xy, 0).xyz;
+   r0.xyz = g_tBloomTexture_5_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r0.xyz = r0.xyz * g_fBloomWeightsCS[5] + r1.xyz;
+   r0.xyz = r2.xyz * g_fBloomWeightsCS[6] + r0.xyz;
+   r0.w = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).x;
+   r0.w = r0.w + r0.w;
+   r1.xyz = r0.xyz * r0.www + -r0.xyz;
+   r0.xyz = g_fLensTextureIntensity * r1.xyz + r0.xyz;
+   r1.xyz = g_tBaseTexture.SampleLevel(g_sLinearClamp_s, v0.xy, 0).xyz;
+   r0.xyz = r1.xyz + r0.xyz;
+   r0.w = g_tBrightness.Load(int3(1, 0, 0));
+   r0.xyz = r0.xyz * r0.www;
+   r1.xy = float2(-0.5, -0.5) + v0.xy;
+   r1.xy = float2(1.70000005, 0.956250012) * r1.xy;
+   r0.w = dot(r1.xy, r1.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r0.xyz = r0.xyz * r0.www;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0xE444CA76.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0xE444CA76.ps_5_0.hlsl
@@ -1,0 +1,224 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:14 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+SamplerState g_sBaseColorCorrectionMap_s : register(s0);
+SamplerState g_sOriginalImage_s : register(s1);
+Texture2D<float4> g_sOriginalImage : register(t0);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t1);
+Texture2D<float> g_tBrightness : register(t2);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v0.xy;
+   r0.zw = float2(1.70000005, 0.956250012) * r0.xy;
+   r1.xyzw = r0.xyxy * g_vTonemapChromaticAberration.xxyy + float4(0.5, 0.5, 0.5, 0.5);
+   r0.x = dot(r0.zw, r0.zw);
+   r0.x = sqrt(r0.x);
+   r0.x = 1 + -r0.x;
+   r0.x = max(0, r0.x);
+   r0.x = 0.0500000007 + r0.x;
+   r0.x = log2(r0.x);
+   r0.x = g_fVignetteExp * r0.x;
+   r0.x = exp2(r0.x);
+   r0.x = 1.04999995 * r0.x;
+   r0.x = min(1, r0.x);
+   r2.x = g_sOriginalImage.Sample(g_sOriginalImage_s, r1.xy).x;
+   r2.z = g_sOriginalImage.Sample(g_sOriginalImage_s, r1.zw).z;
+   r0.y = g_tBrightness.Load(int3(1, 0, 0));
+   r2.yw = g_sOriginalImage.Sample(g_sOriginalImage_s, v0.xy).yw;
+   o0.w = r2.w;
+   r0.yzw = r2.xyz * r0.yyy;
+   r0.xyz = r0.yzw * r0.xxx;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+   return;
+}

--- a/Shaders/Quantum Break/tm_0xFD9D6A90.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_0xFD9D6A90.ps_5_0.hlsl
@@ -1,0 +1,256 @@
+
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:19 2025
+
+cbuffer cb_update_1 : register(b0)
+{
+   float2 g_vScreenRes : packoffset(c0);
+   float2 g_vInvScreenRes : packoffset(c0.z);
+   float2 g_vOutputRes : packoffset(c1);
+   float2 g_vInvOutputRes : packoffset(c1.z);
+   float4x4 g_mWorldToView : packoffset(c2);
+   float4x4 g_mViewToWorld : packoffset(c6);
+   float4x4 g_mViewToClip : packoffset(c10);
+   float4x4 g_mClipToView : packoffset(c14);
+   float4x4 g_mWorldToClip : packoffset(c18);
+   float4x4 g_mClipToWorld : packoffset(c22);
+   float4x4 g_mClipToPreviousClip : packoffset(c26);
+   float4x4 g_mViewToPreviousClip : packoffset(c30);
+   float4x4 g_mPreviousViewToView : packoffset(c34);
+   float4x4 g_mPreviousWorldToClip : packoffset(c38);
+   float4x4 g_mPreviousViewToClip : packoffset(c42);
+   float4 g_vViewPoint : packoffset(c46);
+   float g_fInvNear : packoffset(c47);
+   float g_fSimulationTime : packoffset(c47.y);
+   float g_fSimulationTimeDelta : packoffset(c47.z);
+   float g_fSimulationTimeStep : packoffset(c47.w);
+   uint g_uTemporalFrame : packoffset(c48);
+   uint g_uCurrentFrame : packoffset(c48.y);
+
+   struct
+   {
+      float4 vSunDir;
+      float4 vSunE;
+      float4 vExtinction;
+      float4 vRayleigh;
+      float4 vMie;
+      float4 vSchlickConstants;
+      float4 vFog;
+   }
+g_atmosphere:
+   packoffset(c49);
+
+   float3 g_vFogColor : packoffset(c56);
+   float3 g_vFogColorOpposite : packoffset(c57);
+   float g_fFogExp : packoffset(c57.w);
+   float g_fFogGroundDensityAtViewer : packoffset(c58);
+   float g_fFogGroundHeight : packoffset(c58.y);
+   float g_fFogGroundFalloff : packoffset(c58.z);
+   float g_fFogGroundDensity : packoffset(c58.w);
+   float2 g_vFogGroundDensityMapRange : packoffset(c59);
+   float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+   uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+   float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+   float4 g_fTileDepthRanges[5] : packoffset(c66);
+   float2 g_vDepthTileResolve : packoffset(c71);
+   uint g_uDepthTileCount : packoffset(c71.z);
+   uint2 g_vTileResolution : packoffset(c72);
+   uint3 g_vTileWidthHeightDepth : packoffset(c73);
+   float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+   float2 g_vTileDepthNearFar : packoffset(c74.z);
+   uint g_uMaxPointLightsPerTile : packoffset(c75);
+   uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+   uint g_uAmbientLightTotalCount : packoffset(c75.z);
+   float g_fAmbientEnvIntensity : packoffset(c75.w);
+   float g_fAmbientSkyIntensity : packoffset(c76);
+   float g_fAmbientLocalIntensity : packoffset(c76.y);
+   uint g_uPointLightTotalCount : packoffset(c76.z);
+   uint g_uSpotLightTotalCount : packoffset(c76.w);
+   uint g_uSunLightTotalCount : packoffset(c77);
+   uint g_uAmbientLightEnabled : packoffset(c77.y);
+   float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+   float g_fEnvReflectionMipCount : packoffset(c77.w);
+   float g_fInnerRadius : packoffset(c78);
+   float g_fOuterRadius : packoffset(c78.y);
+   float g_fFadeout : packoffset(c78.z);
+   float4 g_vPlayerViewPosition : packoffset(c79);
+   float4 g_vPlayerWorldPosition : packoffset(c80);
+   float3 g_vDistortionUpInView : packoffset(c81);
+   float3 g_vDistortionUpInWorld : packoffset(c82);
+   float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+   float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+   float g_fFlakeSpawnThreshold : packoffset(c91);
+   float g_fFlakeSpawnProbability : packoffset(c91.y);
+   float g_fParticleLifetime : packoffset(c91.z);
+   float g_fParticleLifetimeDeviation : packoffset(c91.w);
+   float3 g_vParticleVelocity : packoffset(c92);
+   float g_fParticleSpeedDeviation : packoffset(c92.w);
+   float g_fParticleDirectionDeviation : packoffset(c93);
+   float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+   float g_fParticleEmissionFrequency : packoffset(c94);
+   uint4 g_vRandomInts : packoffset(c95);
+   float2 g_vHalfResolutionJitter : packoffset(c96);
+   float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+   float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+   float g_fEnvironmentMapColSize : packoffset(c97);
+   float g_fEnvironmentMapRowSize : packoffset(c97.y);
+   float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+   uint4 g_vVolumeLightDimensions : packoffset(c98);
+   float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+   float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+   float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+   float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+   float3 g_vVolumeLightDepthResolve : packoffset(c103);
+   float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+   float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+   float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+   float g_fVolumeLightKernelWidth : packoffset(c105.z);
+   float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+   float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+   float4x4 g_mTessellationWorldToClip : packoffset(c107);
+   float3 g_fTessellationViewPosition : packoffset(c111);
+   float3 g_fTessellationViewDirection : packoffset(c112);
+   float g_fTessellationViewToClip11 : packoffset(c112.w);
+   float g_fVignetteExp : packoffset(c113);
+   float g_fTonemapKeyValue : packoffset(c113.y);
+   float g_fTonemapGamma : packoffset(c113.z);
+   float g_fTonemapSaturation : packoffset(c113.w);
+   float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+   float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+   float2 g_vTonemapLevels : packoffset(c116);
+   float g_fTonemapNoiseIntensity : packoffset(c116.z);
+   int2 g_vTonemapNoiseOffset : packoffset(c117);
+   float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+   float g_fTonemapBrightness : packoffset(c118);
+   bool g_bUseWBOIT : packoffset(c118.y);
+   float2 g_vViewportRes : packoffset(c118.z);
+   float2 g_vInvViewportRes : packoffset(c119);
+   float2 g_vViewportOffset : packoffset(c119.z);
+   float2 g_vShadowMapRes : packoffset(c120);
+   float2 g_vShadowMapVSMRes : packoffset(c120.z);
+   float2 g_vJitterOffset : packoffset(c121);
+   int2 g_vSnapOffset : packoffset(c121.z);
+   float g_fGIVolumeIntensity : packoffset(c122);
+   float4 g_vScreenToView : packoffset(c123);
+   float4x4 g_mViewToPreviousScreen : packoffset(c124);
+   float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+   float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+   float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+   float g_fViewVolumeDebugDepth : packoffset(c129.w);
+   float3 g_fViewVolumeDebugDirection : packoffset(c130);
+   float3 g_fViewVolumeDebugPosition : packoffset(c131);
+   float3 g_vSunDirVS : packoffset(c132);
+   float3 g_vSunRightVS : packoffset(c133);
+   float3 g_vSunUpVS : packoffset(c134);
+   float3 g_vSunColor : packoffset(c135);
+}
+
+cbuffer bloomx86_compose : register(b1)
+{
+   float2 g_vBloomedImageRes : packoffset(c0);
+   float g_fLensTextureIntensity : packoffset(c0.z);
+}
+
+SamplerState g_sBaseColorCorrectionMap_s : register(s0);
+SamplerState g_sOriginalImage_s : register(s1);
+SamplerState g_sBloomedImage_s : register(s2);
+SamplerState g_sLensTexture_s : register(s3);
+Texture2D<float4> g_sOriginalImage : register(t0);
+Texture2D<float4> g_sBloomedImage : register(t1);
+Texture2D<float4> g_sLensTexture : register(t2);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t3);
+Texture2D<float> g_tBrightness : register(t4);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2, r3, r4, r5;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(0.5, 0.5) / g_vBloomedImageRes.xy;
+   r0.zw = -r0.yx;
+   r1.xyzw = v0.xyxy + r0.xzwy;
+   r2.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r1.xy).xyzw;
+   r1.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r1.zw).xyzw;
+   r0.zw = v0.xy * g_vBloomedImageRes.xy + float2(-0.5, -0.5);
+   r0.zw = frac(r0.zw);
+   r3.xy = float2(1, 1) + -r0.wz;
+   r3.zw = r3.xy * r0.zw;
+   r0.z = r0.z * r0.w;
+   r0.w = r3.y * r3.x;
+   r2.xyzw = r3.zzzz * r2.xyzw;
+   r3.xy = v0.xy + -r0.xy;
+   r0.xy = v0.xy + r0.xy;
+   r4.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r0.xy).xyzw;
+   r5.xyzw = g_sBloomedImage.Sample(g_sBloomedImage_s, r3.xy).xyzw;
+   r2.xyzw = r0.wwww * r5.xyzw + r2.xyzw;
+   r1.xyzw = r3.wwww * r1.xyzw + r2.xyzw;
+   r0.xyzw = r0.zzzz * r4.xyzw + r1.xyzw;
+   r1.xyzw = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).xyzw;
+   r1.xyzw = r1.xyzw * r0.xyzw;
+   r1.xyzw = r1.xyzw * float4(2, 2, 2, 2) + -r0.xyzw;
+   r0.xyzw = g_fLensTextureIntensity * r1.xyzw + r0.xyzw;
+   r1.xyzw = g_sOriginalImage.Sample(g_sOriginalImage_s, v0.xy).xyzw;
+   r0.xyzw = r1.xyzw + r0.xyzw;
+   r1.x = g_tBrightness.Load(int3(1, 0, 0));
+   r0.xyz = r1.xxx * r0.xyz;
+   o0.w = r0.w;
+   r1.xy = float2(-0.5, -0.5) + v0.xy;
+   r1.xy = float2(1.70000005, 0.956250012) * r1.xy;
+   r0.w = dot(r1.xy, r1.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r0.xyz = r0.xyz * r0.www;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz;
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+   return;
+}

--- a/Shaders/Quantum Break/tm_main_0x00658735.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/tm_main_0x00658735.ps_5_0.hlsl
@@ -1,0 +1,279 @@
+#include "./tonemap.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:37:47 2025
+
+// clang-format off
+cbuffer cb_update_1 : register(b0) {
+  float2 g_vScreenRes : packoffset(c0);
+  float2 g_vInvScreenRes : packoffset(c0.z);
+  float2 g_vOutputRes : packoffset(c1);
+  float2 g_vInvOutputRes : packoffset(c1.z);
+  float4x4 g_mWorldToView : packoffset(c2);
+  float4x4 g_mViewToWorld : packoffset(c6);
+  float4x4 g_mViewToClip : packoffset(c10);
+  float4x4 g_mClipToView : packoffset(c14);
+  float4x4 g_mWorldToClip : packoffset(c18);
+  float4x4 g_mClipToWorld : packoffset(c22);
+  float4x4 g_mClipToPreviousClip : packoffset(c26);
+  float4x4 g_mViewToPreviousClip : packoffset(c30);
+  float4x4 g_mPreviousViewToView : packoffset(c34);
+  float4x4 g_mPreviousWorldToClip : packoffset(c38);
+  float4x4 g_mPreviousViewToClip : packoffset(c42);
+  float4 g_vViewPoint : packoffset(c46);
+  float g_fInvNear : packoffset(c47);
+  float g_fSimulationTime : packoffset(c47.y);
+  float g_fSimulationTimeDelta : packoffset(c47.z);
+  float g_fSimulationTimeStep : packoffset(c47.w);
+  uint g_uTemporalFrame : packoffset(c48);
+  uint g_uCurrentFrame : packoffset(c48.y);
+
+  struct
+  {
+    float4 vSunDir;
+    float4 vSunE;
+    float4 vExtinction;
+    float4 vRayleigh;
+    float4 vMie;
+    float4 vSchlickConstants;
+    float4 vFog;
+  } g_atmosphere: packoffset(c49);
+
+  float3 g_vFogColor : packoffset(c56);
+  float3 g_vFogColorOpposite : packoffset(c57);
+  float g_fFogExp : packoffset(c57.w);
+  float g_fFogGroundDensityAtViewer : packoffset(c58);
+  float g_fFogGroundHeight : packoffset(c58.y);
+  float g_fFogGroundFalloff : packoffset(c58.z);
+  float g_fFogGroundDensity : packoffset(c58.w);
+  float2 g_vFogGroundDensityMapRange : packoffset(c59);
+  float3 g_vFogGroundSimulationVelocityAndScale : packoffset(c60);
+  uint g_uCharacterLightRigsBindOffset : packoffset(c60.w);
+  float4 g_fTileDepthClipRanges[5] : packoffset(c61);
+  float4 g_fTileDepthRanges[5] : packoffset(c66);
+  float2 g_vDepthTileResolve : packoffset(c71);
+  uint g_uDepthTileCount : packoffset(c71.z);
+  uint2 g_vTileResolution : packoffset(c72);
+  uint3 g_vTileWidthHeightDepth : packoffset(c73);
+  float2 g_vTileResolutionPerScreenResolution : packoffset(c74);
+  float2 g_vTileDepthNearFar : packoffset(c74.z);
+  uint g_uMaxPointLightsPerTile : packoffset(c75);
+  uint g_uMaxSpotLightsPerTile : packoffset(c75.y);
+  uint g_uAmbientLightTotalCount : packoffset(c75.z);
+  float g_fAmbientEnvIntensity : packoffset(c75.w);
+  float g_fAmbientSkyIntensity : packoffset(c76);
+  float g_fAmbientLocalIntensity : packoffset(c76.y);
+  uint g_uPointLightTotalCount : packoffset(c76.z);
+  uint g_uSpotLightTotalCount : packoffset(c76.w);
+  uint g_uSunLightTotalCount : packoffset(c77);
+  uint g_uAmbientLightEnabled : packoffset(c77.y);
+  float g_fEnvReflectionEdgeLength : packoffset(c77.z);
+  float g_fEnvReflectionMipCount : packoffset(c77.w);
+  float g_fInnerRadius : packoffset(c78);
+  float g_fOuterRadius : packoffset(c78.y);
+  float g_fFadeout : packoffset(c78.z);
+  float4 g_vPlayerViewPosition : packoffset(c79);
+  float4 g_vPlayerWorldPosition : packoffset(c80);
+  float3 g_vDistortionUpInView : packoffset(c81);
+  float3 g_vDistortionUpInWorld : packoffset(c82);
+  float4x4 g_mViewToGeomDistortionViewClip : packoffset(c83);
+  float4x4 g_mWorldToGeomDistortionViewClip : packoffset(c87);
+  float g_fFlakeSpawnThreshold : packoffset(c91);
+  float g_fFlakeSpawnProbability : packoffset(c91.y);
+  float g_fParticleLifetime : packoffset(c91.z);
+  float g_fParticleLifetimeDeviation : packoffset(c91.w);
+  float3 g_vParticleVelocity : packoffset(c92);
+  float g_fParticleSpeedDeviation : packoffset(c92.w);
+  float g_fParticleDirectionDeviation : packoffset(c93);
+  float3 g_vParticleDirectionDeviationScale : packoffset(c93.y);
+  float g_fParticleEmissionFrequency : packoffset(c94);
+  uint4 g_vRandomInts : packoffset(c95);
+  float2 g_vHalfResolutionJitter : packoffset(c96);
+  float g_fInvEnvironmentMapsPerRow : packoffset(c96.z);
+  float g_fEnvironmentMapsPerRow : packoffset(c96.w);
+  float g_fEnvironmentMapColSize : packoffset(c97);
+  float g_fEnvironmentMapRowSize : packoffset(c97.y);
+  float2 g_fInvEnvironmentMapAtlasSize : packoffset(c97.z);
+  uint4 g_vVolumeLightDimensions : packoffset(c98);
+  float4 g_vVolumeLightProjectionConstants : packoffset(c99);
+  float4 g_vHalfResVolumeLightProjectionConstants : packoffset(c100);
+  float3 g_vOnePerVolumeLightDimensions : packoffset(c101);
+  float2 g_vVolumeLightXYToTileXY : packoffset(c102);
+  float3 g_vVolumeLightDepthResolve : packoffset(c103);
+  float g_fVolumeLightOnePerDepthMinusOne : packoffset(c103.w);
+  float3 g_vVolumeLightNearSplit0Far : packoffset(c104);
+  float2 g_vVolumeLightSchlickPhaseConstants : packoffset(c105);
+  float g_fVolumeLightKernelWidth : packoffset(c105.z);
+  float g_fOnePerTranslucencyKernelCount : packoffset(c105.w);
+  float4 g_vTessellation_Density_MaxEdge_MinDst_MaxDst : packoffset(c106);
+  float4x4 g_mTessellationWorldToClip : packoffset(c107);
+  float3 g_fTessellationViewPosition : packoffset(c111);
+  float3 g_fTessellationViewDirection : packoffset(c112);
+  float g_fTessellationViewToClip11 : packoffset(c112.w);
+  float g_fVignetteExp : packoffset(c113);
+  float g_fTonemapKeyValue : packoffset(c113.y);
+  float g_fTonemapGamma : packoffset(c113.z);
+  float g_fTonemapSaturation : packoffset(c113.w);
+  float3 g_vTonemapColorBalanceShadows : packoffset(c114);
+  float3 g_vTonemapColorBalanceHighlights : packoffset(c115);
+  float2 g_vTonemapLevels : packoffset(c116);
+  float g_fTonemapNoiseIntensity : packoffset(c116.z);
+  int2 g_vTonemapNoiseOffset : packoffset(c117);
+  float2 g_vTonemapChromaticAberration : packoffset(c117.z);
+  float g_fTonemapBrightness : packoffset(c118);
+  bool g_bUseWBOIT : packoffset(c118.y);
+  float2 g_vViewportRes : packoffset(c118.z);
+  float2 g_vInvViewportRes : packoffset(c119);
+  float2 g_vViewportOffset : packoffset(c119.z);
+  float2 g_vShadowMapRes : packoffset(c120);
+  float2 g_vShadowMapVSMRes : packoffset(c120.z);
+  float2 g_vJitterOffset : packoffset(c121);
+  int2 g_vSnapOffset : packoffset(c121.z);
+  float g_fGIVolumeIntensity : packoffset(c122);
+  float4 g_vScreenToView : packoffset(c123);
+  float4x4 g_mViewToPreviousScreen : packoffset(c124);
+  float g_fViewVolumeFilterTemporalWeight : packoffset(c128);
+  float g_fViewVolumeOpticalThickness : packoffset(c128.y);
+  float3 g_vViewVolumeParticipatingMediaColor : packoffset(c129);
+  float g_fViewVolumeDebugDepth : packoffset(c129.w);
+  float3 g_fViewVolumeDebugDirection : packoffset(c130);
+  float3 g_fViewVolumeDebugPosition : packoffset(c131);
+  float3 g_vSunDirVS : packoffset(c132);
+  float3 g_vSunRightVS : packoffset(c133);
+  float3 g_vSunUpVS : packoffset(c134);
+  float3 g_vSunColor : packoffset(c135);
+}
+// clang-format on
+
+cbuffer bloomx86CS : register(b1)
+{
+   float g_fBloomIntensityCS : packoffset(c0);
+   float g_fBloomThresholdCS : packoffset(c0.y);
+   float g_fBloomMaxLuminanceCS : packoffset(c0.z);
+   float g_fBloomBlurWeightsCS[5] : packoffset(c1);
+   float g_fBloomWeightsCS[7] : packoffset(c6);
+   float2 g_vScreenResolutionTarget : packoffset(c12.y);
+   float2 g_vBloomCSSourceResolution : packoffset(c13);
+}
+
+cbuffer bloomx86_compose : register(b2)
+{
+   float g_fLensTextureIntensity : packoffset(c0);
+   float4 g_vBloomTextureScaleOffset[7] : packoffset(c1);
+}
+
+SamplerState g_sLinearClamp_s : register(s0);
+SamplerState g_sBaseColorCorrectionMap_s : register(s1);
+SamplerState g_sLensTexture_s : register(s2);
+Texture2D<float4> g_sLensTexture : register(t0);
+Texture2D<float4> g_sBaseColorCorrectionMap : register(t1);
+Texture2D<float> g_tBrightness : register(t2);
+Texture2D<float4> g_tBaseTexture : register(t3);
+Texture2D<float4> g_tBloomTexture_0_ : register(t4);
+Texture2D<float4> g_tBloomTexture_1_ : register(t5);
+Texture2D<float4> g_tBloomTexture_2_ : register(t6);
+Texture2D<float4> g_tBloomTexture_3_ : register(t7);
+Texture2D<float4> g_tBloomTexture_4_ : register(t8);
+Texture2D<float4> g_tBloomTexture_5_ : register(t9);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float2 v0: TEXCOORD0, float4 v1: SV_Position0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1, r2;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xy = float2(-0.5, -0.5) + v1.xy;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[1].xy + g_vBloomTextureScaleOffset[1].zw;
+   r1.xyz = g_tBloomTexture_1_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = g_fBloomWeightsCS[1] * r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[0].xy + g_vBloomTextureScaleOffset[0].zw;
+   r2.xyz = g_tBloomTexture_0_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[0] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[2].xy + g_vBloomTextureScaleOffset[2].zw;
+   r2.xyz = g_tBloomTexture_2_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[2] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[3].xy + g_vBloomTextureScaleOffset[3].zw;
+   r2.xyz = g_tBloomTexture_3_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r1.xyz = r2.xyz * g_fBloomWeightsCS[3] + r1.xyz;
+   r0.zw = r0.xy * g_vBloomTextureScaleOffset[4].xy + g_vBloomTextureScaleOffset[4].zw;
+   r0.xy = r0.xy * g_vBloomTextureScaleOffset[5].xy + g_vBloomTextureScaleOffset[5].zw;
+   r2.xyz = g_tBloomTexture_5_.SampleLevel(g_sLinearClamp_s, r0.xy, 0).xyz;
+   r0.xyz = g_tBloomTexture_4_.SampleLevel(g_sLinearClamp_s, r0.zw, 0).xyz;
+   r0.xyz = r0.xyz * g_fBloomWeightsCS[4] + r1.xyz;
+   r0.xyz = r2.xyz * g_fBloomWeightsCS[5] + r0.xyz;
+   r0.w = g_sLensTexture.Sample(g_sLensTexture_s, v0.xy).x;
+   r0.w = r0.w + r0.w;
+   r1.xyz = r0.xyz * r0.www + -r0.xyz;
+   r0.xyz = g_fLensTextureIntensity * r1.xyz + r0.xyz;
+   r1.xyz = g_tBaseTexture.SampleLevel(g_sLinearClamp_s, v0.xy, 0).xyz;
+   r0.xyz = r1.xyz + r0.xyz;
+   r0.w = g_tBrightness.Load(int3(1, 0, 0));
+   r0.xyz = r0.xyz * r0.www;
+   r1.xy = float2(-0.5, -0.5) + v0.xy;
+   r1.xy = float2(1.70000005, 0.956250012) * r1.xy;
+   r0.w = dot(r1.xy, r1.xy);
+   r0.w = sqrt(r0.w);
+   r0.w = 1 + -r0.w;
+   r0.w = max(0, r0.w);
+   r0.w = 0.0500000007 + r0.w;
+   r0.w = log2(r0.w);
+   r0.w = g_fVignetteExp * r0.w;
+   r0.w = exp2(r0.w);
+   r0.w = 1.04999995 * r0.w;
+   r0.w = min(1, r0.w);
+   r0.xyz = r0.xyz * r0.www;
+   r0.xyz = max(float3(0, 0, 0), r0.xyz);
+   r0.xyz = g_fTonemapKeyValue * r0.xyz; // exposure
+
+// tonemap
+#if 1
+   r0.rgb = ApplyToneMap(r0.xyz);
+#else
+   r0.w = dot(r0.xyz, float3(0.270000011, 0.670000017, 0.0599999987));
+   r1.x = r0.w * 0.015625 + 1;
+   r0.w = 1 + r0.w;
+   r0.w = r1.x / r0.w;
+   r0.xyz = saturate(r0.xyz * r0.www);
+#endif
+
+#if 1
+   r0.rgb = SRGBEncodeAndSample2DLUT(r0.rgb, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+#else
+   r1.xyz = log2(r0.xyz);
+   r1.xyz = float3(0.416666657, 0.416666657, 0.416666657) * r1.xyz;
+   r1.xyz = exp2(r1.xyz);
+   r1.xyz = r1.xyz * float3(1.05499995, 1.05499995, 1.05499995) + float3(-0.0549999997, -0.0549999997, -0.0549999997);
+   r2.xyz = cmp(float3(0.00313080009, 0.00313080009, 0.00313080009) >= r0.xyz);
+   r0.xyz = float3(12.9200001, 12.9200001, 12.9200001) * r0.xyz;
+   r0.xyz = r2.xyz ? r0.xyz : r1.xyz;
+   r0.y = 0.015625 + r0.y;
+   r0.y = max(0.015625, r0.y);
+   r1.z = min(0.984375, r0.y);
+   r0.x = r0.x * 0.03125 + 0.00048828125;
+   r0.y = 32 * r0.z;
+   r0.x = max(0.00048828125, r0.x);
+   r0.z = ceil(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.xz = min(float2(0.0307617188, 0.96875), r0.xz);
+   r1.x = r0.x + r0.z;
+   r2.xyz = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.xz).xyz;
+   r0.z = floor(r0.y);
+   r0.y = frac(r0.y);
+   r0.z = 0.03125 * r0.z;
+   r0.z = max(0, r0.z);
+   r0.z = min(0.96875, r0.z);
+   r1.y = r0.x + r0.z;
+   r0.xzw = g_sBaseColorCorrectionMap.Sample(g_sBaseColorCorrectionMap_s, r1.yz).xyz;
+   r1.xyz = r2.xyz + -r0.xzw;
+   r0.xyz = r0.yyy * r1.xyz + r0.xzw;
+#endif
+
+   // fade?
+   o0.xyz = g_fTonemapBrightness * r0.xyz;
+
+   o0.w = 1;
+   return;
+}

--- a/Shaders/Quantum Break/tonemap.hlsli
+++ b/Shaders/Quantum Break/tonemap.hlsli
@@ -1,0 +1,315 @@
+#include "./quantum_break_common.hlsli"
+
+//-----TONEMAPPING-----//
+float ReinhardExtended(float x, float clip = 1000.f / 203.f, float peak = 1.f, float minimum = 0.f)
+{
+   // float increase = (peak - minimum) / (clip * (clip + minimum));
+   // float scaler = (1.f + (x * increase));
+   // return Reinhard(x, peak, minimum) * scaler;
+
+   // Micro-optimized version below:
+
+   // y = (x + m) / (x/p + 1) * (1 + x(p - m) / c(c + m))
+   // y = p(x + m) / (x + p) * (1 + x(p - m) / c(c + m))
+   // y = p(x + m) * (1 + x(p - m) / c(c + m)) / (x + p)
+   // y = p(x + m) * (c(c + m) + x(p - m)) / ((x + p) * c(c + m))
+   // y = p(x + m) * (c(c + m) + x(p - m)) / ((x + p) * c(c + m))
+
+   // float x_plus_m = x + minimum;                 // (x + m)
+   // float c_plus_m = clip + minimum;              // (c + m)
+   // float cc_plus_cm = clip * c_plus_m;           // c(c + m)
+   // float p_minus_m = peak - minimum;             // (p - m)
+   // float num_a = mad(x, p_minus_m, cc_plus_cm);  // c(c+m) + x(p-m)
+   // float px_plus_pm = peak * x_plus_m;           // p * (x + m)
+   // float num = px_plus_pm * num_a;               // p * (x + m) * (c(c+m) + x(p-m))
+   // float x_plus_p = x + peak;                    // (x + p)
+   // float den = x_plus_p * cc_plus_cm;            // (x + p) * c(c+m)
+   // return num / den;
+
+   // Faster if using outside m, though slightly different
+
+   // y = q(x + 0) * (c(c + 0) + x(q - 0)) / ((x + q) * c(c + 0)) + m
+   // y = q(x) * (c(c + 0) + x(q - 0)) / ((x + q) * c(c + 0)) + m
+   // y = qx * (cc + xq) / ((x + q) * cc) + m
+   // y = xq(cc + xq) / cc(x + q) + m
+
+   float q = peak - minimum;             // q = p - m
+   float xq = x * q;                     // x * q
+   float cc = clip * clip;               // c * c
+   float cc_plus_xq = cc + xq;           // cc + xq
+   float num0 = xq * cc_plus_xq;         // xq(cc + xq)
+   float x_plus_q = x + q;               // x + q
+   float den0 = cc * x_plus_q;           // cc(x + q)
+   float result = num0 / den0 + minimum; // (xqcc + xqxq) / (ccx + ccq) + m
+   return result;
+}
+
+float ComputeReinhardScale(float peak = 1.f, float minimum = 0.f, float gray_in = 0.18f, float gray_out = 0.18f)
+{
+   //  s = (p * y - p * m) / (x * p - x * y)
+
+   float num = peak * (gray_out - minimum); // p * (y - m)
+   float den = gray_in * (peak - gray_out); // x * (p - y)
+
+   return num / den;
+}
+
+float ReinhardExtendedDerivative(float x, float white_max = 1000.f / 203.f, float peak = 1.f)
+{
+   float p = peak, w = white_max;
+   float w2 = w * w;
+
+   // numerator: p^2 * (x(2p + x) + w^2)
+   float num = p * p * (x * (2.f * p + x) + w2);
+
+   // denominator: w^2 * (p + x)^2
+   float px = p + x;
+   float den = w2 * px * px;
+
+   return num / den;
+}
+
+// Cube root that works for negative values too
+float Cbrt(float v)
+{
+    float a = abs(v);
+    if (a == 0.0f) return 0.0f;
+    return sign(v) * pow(a, 1.0f / 3.0f);
+}
+
+// Solve f'(x) = x for the ReinhardExtended luminance curve:
+// f(x)  = (p * x / (p + x)) * (1 + (p * x) / (w * w))
+// f'(x) = p^2 * (w^2 + x * (2p + x)) / (w^2 * (p + x)^2)
+// Returns the Cardano analytic pivot x(p, w).
+float ReinhardExtendedFindPivot(float peak, float white_max)
+{
+   float p = peak;
+   float w = white_max;
+   float p2 = p * p;
+   float p3 = p2 * p;
+   float w2 = w * w;
+
+   // Cubic: a x^3 + b x^2 + c x + d = 0
+   float a = w2;
+   float b = 2.0f * p * w2 - p2;
+   float c = p2 * w2 - 2.0f * p3;
+   float d = -p2 * w2;
+
+   // Normalize: x^3 + A x^2 + B x + C = 0
+   float A = b / a;
+   float B = c / a;
+   float C = d / a;
+
+   // Depressed cubic: t^3 + p_c t + q_c = 0 via x = t - A/3
+   float A2 = A * A;
+   float A3 = A2 * A;
+
+   float p_c = B - (A2 / 3.0f);
+   float q_c = 2.0f * A3 / 27.0f - A * B / 3.0f + C;
+
+   float half_q = 0.5f * q_c;
+   float disc = half_q * half_q + (p_c * p_c * p_c) / 27.0f;
+
+   // Clamp tiny negative due to FP error
+   disc = max(disc, 0.0f);
+
+   float sqrt_disc = sqrt(disc);
+
+   float u = -half_q + sqrt_disc;
+   float v = -half_q - sqrt_disc;
+
+   float u_c = Cbrt(u);
+   float v_c = Cbrt(v);
+
+   float t = u_c + v_c;
+
+   // Back-substitute: x = t - A / 3
+   float x = t - A / 3.0f;
+   return x;
+}
+
+#define APPLY_REINHARD_EXTENDED_PLUS_GENERATOR(T)                                                                      \
+   T ApplyReinhardExtendedPlus(T x, T base, float white_max, float peak = 1.f)                                         \
+   {                                                                                                                   \
+      float pivot_x = ReinhardExtendedFindPivot(peak, white_max);                                                      \
+                                                                                                                       \
+      float pivot_y = ReinhardExtended(pivot_x, white_max, peak);                                                      \
+                                                                                                                       \
+      float slope = ReinhardExtendedDerivative(pivot_x, white_max, peak);                                              \
+                                                                                                                       \
+      /* Line passing through (pivot_x, pivot_y) with matching slope */                                                \
+      T offset = pivot_y - slope * pivot_x;                                                                            \
+      T extended = slope * x + offset;                                                                                 \
+                                                                                                                       \
+      return (x >= pivot_x) ? extended : base;                                                                         \
+   }
+
+APPLY_REINHARD_EXTENDED_PLUS_GENERATOR(float)
+APPLY_REINHARD_EXTENDED_PLUS_GENERATOR(float3)
+#undef APPLY_REINHARD_EXTENDED_PLUS_GENERATOR
+
+float ReinhardPiecewise(float x, float x_max = 1.f, float shoulder = 0.18f)
+{
+   const float x_min = 0.f;
+   float exposure = ComputeReinhardScale(x_max, x_min, shoulder, shoulder);
+   float tonemapped = mad(x, exposure, x_min) / mad(x, exposure / x_max, 1.f - x_min);
+
+   return lerp(x, tonemapped, step(shoulder, x));
+}
+
+float3 ApplyVanillaToneMap(float3 color, float white_clip = 8.f)
+{
+   float luma = dot(color, float3(0.27, 0.67, 0.06));
+   float tonemapped_luma = ReinhardExtended(luma, white_clip, 1.f, 0.f);
+   float scale = (luma > 0.0f) ? (tonemapped_luma / luma) : 1.0f;
+
+   return color * scale;
+}
+
+float3 ApplyVanillaToneMapExtended(float3 color, float white_clip = 8.f)
+{
+   float luma = GetLuminance(color);
+   float base_luma = ReinhardExtended(luma, white_clip, 1.f, 0.f);
+   float extended_lum = ApplyReinhardExtendedPlus(luma, base_luma, white_clip, 1.f);
+   float scale = (luma > 0.0f) ? (extended_lum / luma) : 1.0f;
+
+   return color * scale;
+}
+
+float3 ApplyToneMap(float3 color, float white_clip = 8.f)
+{
+   if (TONE_MAP_TYPE != 0.f)
+   {
+      return ApplyVanillaToneMapExtended(color);
+   }
+   else
+   {
+      return saturate(ApplyVanillaToneMap(color, white_clip));
+   }
+}
+
+float ComputeReinhardSmoothClampScale(float3 untonemapped, float rolloff_start = 0.18f, float output_max = 1.f)
+{
+   float peak = max3(untonemapped.r, untonemapped.g, untonemapped.b);
+
+   float mapped_peak = ReinhardPiecewise(peak, output_max, rolloff_start);
+
+   float scale = safeDivision(mapped_peak, peak, 1);
+
+   return scale;
+}
+
+float ComputeMaxChCompressionScale(float3 color)
+{
+   if (TONE_MAP_TYPE == 0.f)
+   {
+      return 1.f;
+   }
+   else
+   {
+      return ComputeReinhardSmoothClampScale(color, 0.470719f);
+   }
+}
+
+float3 Sample2DLUT(float3 input_color, Texture2D<float4> lut, SamplerState lut_sampler)
+{
+   // 32^3 LUT packed into a 2D strip of 32 slices across X.
+   const float lut_size = 32.0f;
+   const float inv_lut_size = 1.0f / lut_size; // 0.03125
+
+   const float half_texel_x = 1.0f / 2048.0f;    // 0.00048828125
+   const float min_v = 1.0f / 64.0f;             // 0.015625
+   const float max_v = 63.0f / 64.0f;            // 0.984375
+   const float max_u_in_tile = 63.0f / 2048.0f;  // 0.03076171875
+   const float max_slice_offset = 31.0f / 32.0f; // 0.96875
+
+   // Map green to LUT V with the same bias/clamp behavior.
+   float v = clamp(input_color.y + min_v, min_v, max_v);
+
+   // Map red to U within a single slice.
+   float u_in_tile = input_color.x * inv_lut_size + half_texel_x;
+   u_in_tile = clamp(u_in_tile, half_texel_x, max_u_in_tile);
+
+   // Blue selects the LUT slice, with linear interpolation between floor/ceil slices.
+   float slice_pos = lut_size * input_color.z;
+   float slice_t = frac(slice_pos);
+
+   float slice_ceil_offset = ceil(slice_pos) * inv_lut_size;
+   slice_ceil_offset = clamp(slice_ceil_offset, 0.0f, max_slice_offset);
+
+   float slice_floor_offset = floor(slice_pos) * inv_lut_size;
+   slice_floor_offset = clamp(slice_floor_offset, 0.0f, max_slice_offset);
+
+   float2 uv_ceil = float2(u_in_tile + slice_ceil_offset, v);
+   float3 color_ceil = lut.Sample(lut_sampler, uv_ceil).xyz;
+
+   float2 uv_floor = float2(u_in_tile + slice_floor_offset, v);
+   float3 color_floor = lut.Sample(lut_sampler, uv_floor).xyz;
+
+   return lerp(color_floor, color_ceil, slice_t);
+}
+
+float3 Unclamp(float3 original_gamma, float3 black_gamma, float3 mid_gray_gamma, float3 neutral_gamma)
+{
+   const float3 added_gamma = black_gamma;
+
+   const float mid_gray_average = (mid_gray_gamma.r + mid_gray_gamma.g + mid_gray_gamma.b) / 3.f;
+
+   // Remove from 0 to mid-gray
+   const float shadow_length = mid_gray_average;
+   const float shadow_stop = max(neutral_gamma.r, max(neutral_gamma.g, neutral_gamma.b));
+   const float3 floor_remove = added_gamma * max(0, shadow_length - shadow_stop) / shadow_length;
+
+   const float3 unclamped_gamma = max(0, original_gamma - floor_remove);
+   return unclamped_gamma;
+}
+
+float3 ApplyColorGradingLUT(float3 color_input, Texture2D<float4> lut, SamplerState lut_sampler)
+{
+   float3 color_input_encoded = linear_to_sRGB_gamma(color_input);
+   float3 color_output_encoded = Sample2DLUT(color_input_encoded, lut, lut_sampler);
+
+   if (LUT_SCALING > 0.f)
+   {
+      float3 lut_black_encoded = Sample2DLUT(0.f, lut, lut_sampler);
+
+      float lut_black_y = GetLuminance(gamma_sRGB_to_linear(lut_black_encoded));
+      if (lut_black_y > 0.f)
+      {
+         float3 lut_mid_encoded = Sample2DLUT(max(lut_black_encoded, linear_to_sRGB_gamma(0.01f)), lut, lut_sampler);
+
+         float3 unclamped_gamma =
+             Unclamp(color_output_encoded, lut_black_encoded, lut_mid_encoded, color_input_encoded);
+
+         float3 unclamped_linear = gamma_sRGB_to_linear(unclamped_gamma);
+
+         float3 color_output_linear = gamma_sRGB_to_linear(color_output_encoded);
+         color_output_linear *=
+             lerp(1.f, safeDivision(GetLuminance(unclamped_linear), GetLuminance(color_output_linear), 1), LUT_SCALING);
+
+         color_output_encoded = linear_to_sRGB_gamma(color_output_linear);
+      }
+   }
+
+   return color_output_encoded;
+}
+
+float3 SRGBEncodeAndSample2DLUT(float3 input, Texture2D<float4> g_sBaseColorCorrectionMap,
+                                SamplerState g_sBaseColorCorrectionMap_s)
+{
+   float4 r0;
+   float3 r1, r2;
+
+   float scale = ComputeMaxChCompressionScale(input);
+
+   float3 input_scaled = input * scale;
+
+   r0.rgb = ApplyColorGradingLUT(input_scaled, g_sBaseColorCorrectionMap, g_sBaseColorCorrectionMap_s);
+
+   r0.rgb = gamma_sRGB_to_linear(r0.rgb);
+   r0.rgb /= scale;
+   r0.rgb = lerp(input, r0.rgb, LUT_STRENGTH);
+   r0.rgb = linear_to_sRGB_gamma(r0.rgb);
+
+   return r0.rgb;
+}

--- a/Shaders/Quantum Break/unused/ui_0xE9BD5102.ps_5_0.hlsl
+++ b/Shaders/Quantum Break/unused/ui_0xE9BD5102.ps_5_0.hlsl
@@ -1,0 +1,31 @@
+#include "./common.hlsli"
+
+// ---- Created with 3Dmigoto v1.4.1 on Mon Jan 27 21:38:16 2025
+
+cbuffer embedded_shapeengine : register(b0)
+{
+   float4x4 g_mShapeEngineColorTransform : packoffset(c0);
+   float4 g_vShapeEngineColorAdd : packoffset(c4);
+}
+
+SamplerState g_sTexture_s : register(s0);
+Texture2D<float4> g_sTexture : register(t0);
+
+// 3Dmigoto declarations
+#define cmp -
+
+void main(float3 v0: TEXCOORD0, float4 v1: COLOR0, out float4 o0: SV_Target0)
+{
+   float4 r0, r1;
+   uint4 bitmask, uiDest;
+   float4 fDest;
+
+   r0.xyzw = g_sTexture.Sample(g_sTexture_s, v0.xy).xyzw;
+   r0.xyzw = v1.xyzw * r0.xyzw;
+   r1.xyzw = g_mShapeEngineColorTransform._m01_m11_m21_m31 * r0.yyyy;
+   r1.xyzw = g_mShapeEngineColorTransform._m00_m10_m20_m30 * r0.xxxx + r1.xyzw;
+   r1.xyzw = g_mShapeEngineColorTransform._m02_m12_m22_m32 * r0.zzzz + r1.xyzw;
+   r0.xyzw = g_mShapeEngineColorTransform._m03_m13_m23_m33 * r0.wwww + r1.xyzw;
+   o0.xyzw = g_vShapeEngineColorAdd.xyzw + r0.xyzw;
+   return;
+}

--- a/Source/Games/Quantum Break/Quantum Break.vcxproj
+++ b/Source/Games/Quantum Break/Quantum Break.vcxproj
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Development-Debug|Win32">
+      <Configuration>Development-Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Debug|x64">
+      <Configuration>Development-Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Release|Win32">
+      <Configuration>Development-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Development-Release|x64">
+      <Configuration>Development-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Publishing-Release|Win32">
+      <Configuration>Publishing-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Publishing-Release|x64">
+      <Configuration>Publishing-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Test-Release|Win32">
+      <Configuration>Test-Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Test-Release|x64">
+      <Configuration>Test-Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{3898C29D-83BD-406E-B891-7E2D4BDB34DF}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <Platform>x64</Platform>
+    <ProjectName>Quantum Break</ProjectName>
+    <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
+    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows</VcpkgTriplet>
+    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows</VcpkgTriplet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.20506.1</_ProjectFileVersion>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">true</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">true</GenerateManifest>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">$(SolutionName)-$(ProjectName)</TargetName>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">.addon</TargetExt>
+    <TargetExt Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">.addon</TargetExt>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">false</LinkIncremental>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">true</GenerateManifest>
+    <GenerateManifest Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">true</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">
+    <IntDir>$(SolutionDir)\Binaries\Intermediate\$(ShortProjectName)-$(Platform)-$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)\Binaries\$(Platform)-$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg">
+    <VcpkgEnableManifest>false</VcpkgEnableManifest>
+    <VcpkgEnabled>false</VcpkgEnabled>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'" Label="Vcpkg" />
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'" Label="Vcpkg" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'" Label="Vcpkg" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_DEBUG;_WINDOWS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_DEBUG;_WINDOWS</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;NDEBUG;TEST=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";_WINDOWS;NDEBUG;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x64</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Publishing-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;TEST=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Development-Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);SOLUTION_DIR=R"($(SolutionDir))";PROJECT_NAME="$(ProjectName)";WIN32;_WINDOWS;NDEBUG;DEVELOPMENT=1;</PreprocessorDefinitions>
+      <UseStandardPreprocessor>true</UseStandardPreprocessor>
+      <AdditionalOptions>%(AdditionalOptions) /utf-8 /Zc:strictStrings /Zc:threadSafeInit</AdditionalOptions>
+      <FunctionLevelLinking>
+      </FunctionLevelLinking>
+      <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <LanguageStandard_C>stdclatest</LanguageStandard_C>
+      <ForcedIncludeFiles>%(ForcedIncludeFiles)</ForcedIncludeFiles>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);WIN32;_WINDOWS;NDEBUG</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Midl>
+      <AdditionalIncludeDirectories>.\.\External\reshade;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
+      <HeaderFileName>%(Filename).h</HeaderFileName>
+      <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
+      <InterfaceIdentifierFileName>%(Filename)_i.c</InterfaceIdentifierFileName>
+      <ProxyFileName>%(Filename)_p.c</ProxyFileName>
+    </Midl>
+    <Link>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
+      <AdditionalLibraryDirectories>
+      </AdditionalLibraryDirectories>
+      <AdditionalOptions>%(AdditionalOptions) /machine:x86</AdditionalOptions>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <ImportLibrary>
+      </ImportLibrary>
+    </Link>
+    <ProjectReference>
+      <LinkLibraryDependencies>
+      </LinkLibraryDependencies>
+    </ProjectReference>
+    <PostBuildEvent>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Source/Games/Quantum Break/Quantum Break.vcxproj.filters
+++ b/Source/Games/Quantum Break/Quantum Break.vcxproj.filters
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="..\..\Core\unity_build.cpp" />
+  </ItemGroup>
+</Project>

--- a/Source/Games/Quantum Break/THIRD_PARTY_NOTICES.txt
+++ b/Source/Games/Quantum Break/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,33 @@
+Third-Party Notices for Quantum Break Luma Mod
+==============================================
+
+This folder includes third-party code under the MIT License.
+
+Component: Neutwo tonemapper (from RenoDX)
+Source: https://github.com/clshortfuse/renodx
+License: MIT
+Copyright: Copyright (c) 2026 Carlos Lopez Jr.
+
+----
+
+MIT License
+
+Copyright (c) 2026 Carlos Lopez Jr.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Source/Games/Quantum Break/main.cpp
+++ b/Source/Games/Quantum Break/main.cpp
@@ -1,0 +1,79 @@
+#define GAME_QUANTUM_BREAK 1
+
+#include "..\..\Core\core.hpp"
+
+class QuantumBreakGame final : public Game
+{
+public:
+   void OnInit(bool async) override
+   {
+      // ### Update these (find the right values) ###
+      // ### See the "GameCBuffers.hlsl" in the shader directory to expand settings ###
+      luma_settings_cbuffer_index = 13;
+      luma_data_cbuffer_index = 12;
+   }
+
+   void PrintImGuiAbout() override
+   {
+      ImGui::Text("Luma for \"Quantum Break\" is developed by Musa and is open source and free.\nIf you enjoy it, consider donating.");
+
+      ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(70, 134, 0, 255));
+      ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(70 + 9, 134 + 9, 0, 255));
+      ImGui::PushStyleColor(ImGuiCol_ButtonActive, IM_COL32(70 + 18, 134 + 18, 0, 255));
+      static const std::string donation_link_musa = std::string("Buy Musa a Coffee on ko-fi ") + std::string(ICON_FK_OK);
+      if (ImGui::Button(donation_link_musa.c_str()))
+      {
+         system("start https://ko-fi.com/musaqh");
+      }
+      ImGui::PopStyleColor(3);
+
+      ImGui::NewLine();
+      static const std::string social_link = std::string("Join our \"HDR Den\" Discord ") + std::string(ICON_FK_SEARCH);
+      if (ImGui::Button(social_link.c_str()))
+      {
+         // Unique link for Luma by Pumbo (to track the origin of people joining), do not share for other purposes
+         static const std::string obfuscated_link = std::string("start https://discord.gg/J9fM") + std::string("3EVuEZ");
+         system(obfuscated_link.c_str());
+      }
+
+      ImGui::NewLine();
+      ImGui::Text("Build Date:");
+      ImGui::Text(__DATE__);
+      ImGui::Text(__TIME__);
+      ImGui::NewLine();
+
+      ImGui::Text("Credits:"
+                  "\nPumbo"
+
+                  "\n\nThird Party:"
+                  "\nReShade"
+                  "\nImGui"
+                  "\nShortFuse (Neutwo tonemapper)"
+                  "");
+   }
+};
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+   if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+   {
+      Globals::SetGlobals(PROJECT_NAME, "Quantum Break Luma mod", "https://ko-fi.com/musaqh");
+      Globals::VERSION = 1;
+
+      swapchain_format_upgrade_type = TextureFormatUpgradesType::AllowedEnabled;
+      swapchain_upgrade_type = SwapchainUpgradeType::scRGB;
+      texture_format_upgrades_type = TextureFormatUpgradesType::AllowedEnabled;
+      // ### Check which of these are needed and remove the rest ###
+      texture_upgrade_formats = {
+         reshade::api::format::r11g11b10_float,
+      };
+      // ### Check these if textures are not upgraded ###
+      texture_format_upgrades_2d_size_filters = 0 | static_cast<uint32_t>(TextureFormatUpgrades2DSizeFilters::SwapchainResolution) | static_cast<uint32_t>(TextureFormatUpgrades2DSizeFilters::SwapchainAspectRatio);
+
+      game = new QuantumBreakGame();
+   }
+
+   CoreMain(hModule, ul_reason_for_call, lpReserved);
+
+   return TRUE;
+}

--- a/Source/Games/Quantum Break/main.cpp
+++ b/Source/Games/Quantum Break/main.cpp
@@ -15,7 +15,7 @@ public:
 
    void PrintImGuiAbout() override
    {
-      ImGui::Text("Luma for \"Quantum Break\" is developed by Musa and is open source and free.\nIf you enjoy it, consider donating.");
+      ImGui::Text("Luma for \"Quantum Break\" is developed by Musa and is open source and free.\nIf you enjoy it, consider donating.\n");
 
       ImGui::PushStyleColor(ImGuiCol_Button, IM_COL32(70, 134, 0, 255));
       ImGui::PushStyleColor(ImGuiCol_ButtonHovered, IM_COL32(70 + 9, 134 + 9, 0, 255));
@@ -35,11 +35,14 @@ public:
          static const std::string obfuscated_link = std::string("start https://discord.gg/J9fM") + std::string("3EVuEZ");
          system(obfuscated_link.c_str());
       }
+      static const std::string contributing_link = std::string("Contribute on Github ") + std::string(ICON_FK_FILE_CODE);
+      if (ImGui::Button(contributing_link.c_str()))
+      {
+         system("start https://github.com/Filoppi/Luma-Framework");
+      }
 
       ImGui::NewLine();
-      ImGui::Text("Build Date:");
-      ImGui::Text(__DATE__);
-      ImGui::Text(__TIME__);
+      ImGui::Text("Build Date: %s %s", __DATE__, __TIME__);
       ImGui::NewLine();
 
       ImGui::Text("Credits:"
@@ -48,8 +51,13 @@ public:
                   "\n\nThird Party:"
                   "\nReShade"
                   "\nImGui"
-                  "\nShortFuse (Neutwo tonemapper)"
+                  "\nNeutwo (from RenoDX) - Copyright (c) 2026 Carlos Lopez Jr. Licensed under MIT."
                   "");
+      static const std::string neutwo_license_link = std::string("RenoDX MIT License ") + std::string(ICON_FK_SEARCH);
+      if (ImGui::Button(neutwo_license_link.c_str()))
+      {
+         system("start https://github.com/clshortfuse/renodx/blob/main/LICENSE");
+      }
    }
 };
 


### PR DESCRIPTION
- add Quantum Break to games list
- add HDR tonemapping support with ReinhardExtendedPlus replacing vanilla's ReinhardExtended and Neutwo for display mapping
- sample luts using ReinhardPiecewise 
- add LUT scaling support
