### PR TITLE
Improve Quantum Break DLSS depth, jitter, and transition handlingvior, transition handling, PDB behavior, and validation status.

### DIFF
--- a/Source/Games/Quantum Break/Quantum Break.vcxproj
+++ b/Source/Games/Quantum Break/Quantum Break.vcxproj
@@ -153,6 +153,7 @@
     <PostBuildEvent>
       <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH (
   xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0
+  IF EXIST "$(TargetDir)$(TargetName).pdb" ( xcopy /Y "$(TargetDir)$(TargetName).pdb" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )
   IF EXIST "..\..\External\NGX\bin\dev\nvngx_dlss.dll" ( xcopy /Y "..\..\External\NGX\bin\dev\nvngx_dlss.dll" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )
 )</Command>
     </PostBuildEvent>
@@ -253,6 +254,7 @@
     <PostBuildEvent>
       <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH (
   xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0
+  IF EXIST "$(TargetDir)$(TargetName).pdb" ( xcopy /Y "$(TargetDir)$(TargetName).pdb" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )
   IF EXIST "..\..\External\NGX\bin\rel\nvngx_dlss.dll" ( xcopy /Y "..\..\External\NGX\bin\rel\nvngx_dlss.dll" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )
 )</Command>
     </PostBuildEvent>
@@ -301,7 +303,10 @@
       </LinkLibraryDependencies>
     </ProjectReference>
     <PostBuildEvent>
-      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH ( xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )</Command>
+      <Command>IF DEFINED LUMA_QUANTUM_BREAK_BIN_PATH (
+  xcopy /Y "$(TargetDir)*$(SolutionName)-$(ProjectName).addon" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0
+  IF EXIST "$(TargetDir)$(TargetName).pdb" ( xcopy /Y "$(TargetDir)$(TargetName).pdb" "%LUMA_QUANTUM_BREAK_BIN_PATH%" || exit /B 0 )
+)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Games/Quantum Break/Upscaling.hpp
+++ b/Source/Games/Quantum Break/Upscaling.hpp
@@ -67,13 +67,22 @@ namespace QuantumBreakUpscaling
    }
 
    constexpr float vertical_fov_fallback = 0.775934f; // ~44.46 degrees
+   // Counted in valid scene temporal-resolve draws, not seconds. DLSS is held off for this many
+   // resolves after startup/loading/no-scene periods so QB's AA-off scene transition can stabilize.
+   constexpr uint32_t dlss_scene_warmup_resolve_count = 120u;
    // Byte offsets into QB's cb_update_1 cbuffer for the SR inputs that are not available from textures.
    constexpr uint32_t cb_update_1_inv_near_offset = 47u * 16u;
    constexpr uint32_t cb_update_1_view_to_clip_offset = 10u * 16u;
    constexpr uint32_t cb_update_1_tess_view_to_clip_11_offset = 112u * 16u + 12u;
    constexpr uint32_t cb_update_1_jitter_offset = 121u * 16u;
    constexpr uint32_t cb_update_1_min_size = cb_update_1_jitter_offset + sizeof(float) * 2u;
-   // The temporal resolve samples current color with g_vSSAAJitterOffset[0].
+   // The temporal resolve samples current color with g_vSSAAJitterOffset[0], directly added to UVs.
+   // Logged scene frames repeat a 4-sample raw UV pattern:
+   //   ( 0.00014648, -0.00008681), (-0.00014648,  0.00008681),
+   //   ( 0.00004883,  0.00026042), (-0.00004883, -0.00026042).
+   // At 2560x1440, observed when QB's own upscaling is enabled for 4K output,
+   // this becomes roughly (0.375, 0.125), (-0.375, -0.125),
+   // (0.125, -0.375), (-0.125, 0.375) render pixels after the SR Y flip.
    constexpr uint32_t ssaa_jitter_offset = 12u * 16u;
    constexpr uint32_t ssaa_min_size = ssaa_jitter_offset + sizeof(float) * 2u;
 
@@ -101,6 +110,8 @@ namespace QuantumBreakUpscaling
       float sr_jitter_y = 0.f;
       float sr_cb_jitter_x = 0.f;
       float sr_cb_jitter_y = 0.f;
+      float sr_render_pixel_jitter_x = 0.f;
+      float sr_render_pixel_jitter_y = 0.f;
       float sr_vertical_fov = vertical_fov_fallback;
       float sr_near_plane = 0.1f;
       float sr_far_plane = 1000.f;
@@ -121,6 +132,10 @@ namespace QuantumBreakUpscaling
       uint32_t previous_render_height = 0u;
       uint32_t previous_output_width = 0u;
       uint32_t previous_output_height = 0u;
+      // DLSS transition state. previous_sr_type detects switching into DLSS; dlss_scene_warmup_remaining
+      // also gets refreshed by no-scene frames so DLSS does not start on the first unstable gameplay resolves.
+      uint32_t dlss_scene_warmup_remaining = 0u;
+      SR::Type previous_sr_type = SR::Type::None;
 #endif
    };
 
@@ -205,7 +220,9 @@ namespace QuantumBreakUpscaling
       }
 
       const float fov = 2.f * std::atan(1.f / abs_projection_scale);
-      return (std::isfinite(fov) && fov > 0.f && fov < 3.13f) ? fov : 0.f;
+      // Loading/menu variants of QB's temporal resolve can expose non-scene constants that decode to a
+      // technically positive but effectively zero FOV. Do not feed those into DLSS; keep the previous/fallback FOV.
+      return (std::isfinite(fov) && fov >= 0.1f && fov < 3.13f) ? fov : 0.f;
    }
 
    inline bool HasTextureShapeChanged(const D3D11_TEXTURE2D_DESC& current_desc, const D3D11_TEXTURE2D_DESC& previous_desc)
@@ -428,7 +445,8 @@ namespace QuantumBreakUpscaling
 
    inline bool CaptureSSAAData(ID3D11Device* native_device, ID3D11DeviceContext* native_device_context, Data& data)
    {
-      // The temporal resolve samples current color with g_vSSAAJitterOffset[0], so keep this as the jitter source.
+      // Prefer the temporal resolve's SSAA jitter over cb_update_1. It is the exact UV offset
+      // used for the current color/depth sample, and the captured values identify QB's 4-sample pattern.
       data.has_ssaa_data = false;
       data.sr_jitter_x = 0.f;
       data.sr_jitter_y = 0.f;
@@ -626,7 +644,13 @@ namespace QuantumBreakUpscaling
       result.requested = IsRequested(device_data);
 
 #if ENABLE_SR
-   data.used_cached_clip_depth = false;
+      data.used_cached_clip_depth = false;
+      // Switching into DLSS is equivalent to a fresh scene start for DLSS history purposes.
+      if (data.previous_sr_type != device_data.sr_type)
+      {
+         data.previous_sr_type = device_data.sr_type;
+         data.dlss_scene_warmup_remaining = device_data.sr_type == SR::Type::DLSS ? dlss_scene_warmup_resolve_count : 0u;
+      }
 
       com_ptr<ID3D11ShaderResourceView> ps_shader_resources[3];
       com_ptr<ID3D11RenderTargetView> render_target_views[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];
@@ -645,10 +669,38 @@ namespace QuantumBreakUpscaling
          return ps_shader_resources[0].get() && ps_shader_resources[2].get() && render_target_views[0].get();
       }();
 
+      bool captured_cb_update_1 = false;
+      bool captured_ssaa = false;
       if (has_main_temporal_resolve_bindings)
       {
-         CaptureCBUpdate1Data(native_device, native_device_context, data);
-         CaptureSSAAData(native_device, native_device_context, data);
+         // These constant buffers distinguish the real scene temporal resolve from transition variants
+         // that use the same shader/resources but do not carry valid scene camera/jitter state.
+         captured_cb_update_1 = CaptureCBUpdate1Data(native_device, native_device_context, data);
+         captured_ssaa = CaptureSSAAData(native_device, native_device_context, data);
+      }
+
+      if (result.requested && has_main_temporal_resolve_bindings && !captured_cb_update_1 && !captured_ssaa)
+      {
+         // Loading-to-gameplay transition resolves can bind scene-looking resources without the scene
+         // constant buffers. Do not run SR, and do not replay the draw through the post-SR resolve path.
+         device_data.force_reset_sr = true;
+         if (cb_luma_global_settings.SRType != 0u)
+         {
+            cb_luma_global_settings.SRType = 0u;
+            device_data.cb_luma_global_settings_dirty = true;
+         }
+         result.stop_processing = true;
+         return result;
+      }
+
+      if (result.requested && device_data.sr_type == SR::Type::DLSS && has_main_temporal_resolve_bindings && captured_cb_update_1 && captured_ssaa && data.dlss_scene_warmup_remaining > 0u)
+      {
+         // This is not a wall-clock delay: it consumes one count per valid scene temporal resolve.
+         // During the warmup, QB's own temporal resolve runs normally and DLSS history is kept reset.
+         --data.dlss_scene_warmup_remaining;
+         device_data.force_reset_sr = true;
+         result.requested = false;
+         return result;
       }
 
       if (result.requested && immediate_context && data.sr_motion_vectors.get() && has_main_temporal_resolve_bindings)
@@ -709,16 +761,17 @@ namespace QuantumBreakUpscaling
                   data.used_cached_clip_depth = true;
                }
 
-               if (SetupOutput(native_device, device_data, data, output_desc))
+               const bool output_ready = SetupOutput(native_device, device_data, data, output_desc);
+               if (output_ready)
                {
                   auto* sr_instance_data = device_data.GetSRInstanceData();
                   if (sr_instance_data)
                   {
-                     // Use the smallest SR input texture so color, depth, and motion vectors cover the full render area.
-                     const uint32_t max_input_width = (std::min)(source_desc.Width, (std::min)(depth_desc.Width, motion_vectors_desc.Width));
-                     const uint32_t max_input_height = (std::min)(source_desc.Height, (std::min)(depth_desc.Height, motion_vectors_desc.Height));
-                     const uint32_t render_width = max_input_width;
-                     const uint32_t render_height = max_input_height;
+                     // Use the smallest SR input texture so color, depth, and motion vectors all cover the full render area.
+                     const uint32_t input_width = (std::min)(source_desc.Width, (std::min)(depth_desc.Width, motion_vectors_desc.Width));
+                     const uint32_t input_height = (std::min)(source_desc.Height, (std::min)(depth_desc.Height, motion_vectors_desc.Height));
+                     const uint32_t render_width = input_width;
+                     const uint32_t render_height = input_height;
 
                      const uint32_t output_width = output_desc.Width;
                      const uint32_t output_height = output_desc.Height;
@@ -730,6 +783,22 @@ namespace QuantumBreakUpscaling
                         device_data.force_reset_sr = true;
                         result.stop_processing = true;
                         return result;
+                     }
+
+                     // g_vSSAAJitterOffset[0] is a normalized UV offset; shader 0x99274617 adds it directly to sampling UVs.
+                     // Convert UV -> input pixels for DLSS/FSR and flip Y to match SR convention. Do not apply
+                     // projection/NDC-style *0.5f scaling here; that would make the logged pattern half-strength.
+                     if (data.has_ssaa_data)
+                     {
+                        data.sr_render_pixel_jitter_x = jitter_x * static_cast<float>(render_width);
+                        data.sr_render_pixel_jitter_y = -jitter_y * static_cast<float>(render_height);
+                     }
+                     else
+                     {
+                        // Fallback g_vJitterOffset is not the temporal resolve sample offset. Captured scene frames had it
+                        // at zero, and other QB shaders add it to SV_Position, so treat it as already pixel-space if used.
+                        data.sr_render_pixel_jitter_x = jitter_x;
+                        data.sr_render_pixel_jitter_y = -jitter_y;
                      }
 
                      Settings::SetRenderData(render_width, render_height, output_width, output_height, jitter_x, jitter_y, device_data);
@@ -780,9 +849,9 @@ namespace QuantumBreakUpscaling
                         draw_data.motion_vectors = data.sr_motion_vectors.get();
                         draw_data.depth_buffer = sr_depth_resource;
                         draw_data.pre_exposure = 1.f;
-                        draw_data.jitter_x = jitter_x * Settings::jitter_scale;
-                        draw_data.jitter_y = jitter_y * Settings::jitter_scale;
-                        draw_data.vert_fov = (std::isfinite(data.sr_vertical_fov) && data.sr_vertical_fov > 0.f)
+                        draw_data.jitter_x = data.sr_render_pixel_jitter_x * Settings::jitter_scale;
+                        draw_data.jitter_y = data.sr_render_pixel_jitter_y * Settings::jitter_scale;
+                        draw_data.vert_fov = (std::isfinite(data.sr_vertical_fov) && data.sr_vertical_fov >= 0.1f)
                                                 ? data.sr_vertical_fov
                                                 : vertical_fov_fallback;
                         draw_data.near_plane = data.sr_near_plane;
@@ -807,7 +876,12 @@ namespace QuantumBreakUpscaling
                            source_desc.Width,
                            source_desc.Height);
 
-                        result.succeeded = pre_sr_encoded && sr_implementations[device_data.sr_type]->Draw(sr_instance_data, native_device_context, draw_data);
+                        bool sr_drawn = false;
+                        if (pre_sr_encoded)
+                        {
+                           sr_drawn = sr_implementations[device_data.sr_type]->Draw(sr_instance_data, native_device_context, draw_data);
+                        }
+                        result.succeeded = pre_sr_encoded && sr_drawn;
 
                         {
                            ID3D11ShaderResourceView* null_srvs[D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT] = {};
@@ -891,6 +965,7 @@ namespace QuantumBreakUpscaling
    {
 #if ENABLE_SR
       // Drop all transient SR resources so the next valid scene frame rebuilds them and resets DLSS history.
+      // If DLSS is currently selected, the rebuild is also treated as a fresh scene warmup.
       device_data.force_reset_sr = true;
       device_data.has_drawn_sr = false;
 
@@ -903,6 +978,8 @@ namespace QuantumBreakUpscaling
       data.output_changed = false;
       data.has_sr_clip_depth_desc = false;
       data.used_cached_clip_depth = false;
+      data.sr_render_pixel_jitter_x = 0.f;
+      data.sr_render_pixel_jitter_y = 0.f;
 
       data.has_previous_source_desc = false;
       data.has_previous_depth_desc = false;
@@ -915,6 +992,7 @@ namespace QuantumBreakUpscaling
       data.previous_render_height = 0u;
       data.previous_output_width = 0u;
       data.previous_output_height = 0u;
+      data.dlss_scene_warmup_remaining = device_data.sr_type == SR::Type::DLSS ? dlss_scene_warmup_resolve_count : 0u;
 #else
       (void)device_data;
       (void)data;
@@ -924,10 +1002,20 @@ namespace QuantumBreakUpscaling
    inline void OnPresent(DeviceData& device_data, Data& data)
    {
 #if ENABLE_SR
+      const bool had_clip_depth = data.sr_clip_depth.get() != nullptr;
+      const bool had_motion_vectors = data.sr_motion_vectors.get() != nullptr;
+
       // If SR was requested but no scene resolve produced SR output, force a history reset for the next scene frame.
       if (device_data.sr_type != SR::Type::None && !device_data.has_drawn_sr)
       {
          device_data.force_reset_sr = true;
+      }
+
+      if (device_data.sr_type == SR::Type::DLSS && !device_data.has_drawn_sr && !had_clip_depth && !had_motion_vectors)
+      {
+         // Title/loading/UI-only frames do not provide a real scene depth/MV pair. Refresh the DLSS warmup
+         // so DLSS waits for stable gameplay resolves once scene rendering resumes.
+         data.dlss_scene_warmup_remaining = (std::max)(data.dlss_scene_warmup_remaining, dlss_scene_warmup_resolve_count);
       }
 
       data.debug_prev_had_clip_depth = data.sr_clip_depth.get() != nullptr;
@@ -1022,6 +1110,13 @@ namespace QuantumBreakUpscaling
             table_row_uint("Last SR Render Height:", data.previous_render_height);
             table_row_uint("Last SR Output Width:", data.previous_output_width);
             table_row_uint("Last SR Output Height:", data.previous_output_height);
+            table_row_bool("Using SSAA Jitter Source:", data.has_ssaa_data);
+            table_row_float("Last Raw SSAA Jitter X:", data.sr_jitter_x);
+            table_row_float("Last Raw SSAA Jitter Y:", data.sr_jitter_y);
+            table_row_float("Last Raw CB Jitter X:", data.sr_cb_jitter_x);
+            table_row_float("Last Raw CB Jitter Y:", data.sr_cb_jitter_y);
+            table_row_float("Last SR Pixel Jitter X:", data.sr_render_pixel_jitter_x);
+            table_row_float("Last SR Pixel Jitter Y:", data.sr_render_pixel_jitter_y);
             table_row_float("Active MV Scale Multiplier:", Settings::mv_scale);
             table_row_float("Active Jitter Scale Multiplier:", Settings::jitter_scale);
             ImGui::EndTable();

--- a/Source/Games/Quantum Break/Upscaling.hpp
+++ b/Source/Games/Quantum Break/Upscaling.hpp
@@ -2,12 +2,28 @@
 
 #include "shared.h"
 
-// Quantum Break's SR hook sits inside the temporal resolve path:
-// history reprojection provides motion vectors, temporal resolve provides color/depth/cbuffer inputs,
-// and a fullscreen pre-decode pass lets DLSS run on linear color while the game remains gamma-space.
+// Quantum Break's SR hook is assembled from several stable Remedy passes:
+// - 0xA43343D6 "Depth Linearization" reads clip/device depth from PS SRV0 and writes linear depth to RTV0.
+//   We cache the PS SRV0 input, not the linearized RTV output, so SR receives pre-linearized depth.
+// - 0xE8337D48 "History Reprojection" reads the geometry velocity texture from CS SRV0.
+// - 0x99274617 "Temporal Resolve" is the SR insertion point. It provides source color in PS SRV2,
+//   final output in OM RTV0, temporal cbuffer data in PS CB0/CB1, and a same-depth fallback in PS SRV0.
+// - Luma_QB_PreSRDecode converts QB's gamma-space temporal source color to linear before DLSS/FSR.
 namespace QuantumBreakUpscaling
 {
-   // Pass hashes used to identify the two parts of QB's temporal pipeline we need to observe/replace.
+   constexpr uint32_t hash_depth_linearization = 0xA43343D6u;
+   constexpr uint32_t hash_history_reprojection = 0xE8337D48u;
+   constexpr uint32_t hash_temporal_resolve = 0x99274617u;
+   constexpr uint32_t hash_msaa_gbuffer_reconstruction = 0x037FCE62u;
+   constexpr uint32_t hash_msaa_gbuffer_depth_resolve = 0x84DD3C0Cu;
+
+   // Pass hashes used to identify the parts of QB's depth/temporal pipeline we need to observe/replace.
+   inline ShaderHashesList<>& DepthLinearizationHashes()
+   {
+      static ShaderHashesList<> hashes;
+      return hashes;
+   }
+
    inline ShaderHashesList<>& HistoryReprojectionHashes()
    {
       static ShaderHashesList<> hashes;
@@ -22,8 +38,22 @@ namespace QuantumBreakUpscaling
 
    inline void RegisterShaderHashes()
    {
-      HistoryReprojectionHashes().compute_shaders.emplace(std::stoul("E8337D48", nullptr, 16));
-      TemporalResolveHashes().pixel_shaders.emplace(std::stoul("99274617", nullptr, 16));
+      DepthLinearizationHashes().pixel_shaders.emplace(hash_depth_linearization);
+      HistoryReprojectionHashes().compute_shaders.emplace(hash_history_reprojection);
+      TemporalResolveHashes().pixel_shaders.emplace(hash_temporal_resolve);
+
+#if DEVELOPMENT
+      forced_shader_names.emplace(hash_depth_linearization, "QB Depth Linearization (Clip Depth -> Linear Depth)");
+      forced_shader_names.emplace(hash_history_reprojection, "QB History Reprojection (Motion Vectors)");
+      forced_shader_names.emplace(hash_temporal_resolve, "QB Temporal Resolve / TAA");
+      forced_shader_names.emplace(hash_msaa_gbuffer_reconstruction, "QB MSAA GBuffer Reconstruction Mask");
+      forced_shader_names.emplace(hash_msaa_gbuffer_depth_resolve, "QB MSAA GBuffer Depth Resolve");
+#endif
+   }
+
+   inline bool IsDepthLinearizationPass(const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes)
+   {
+      return original_shader_hashes.Contains(DepthLinearizationHashes());
    }
 
    inline bool IsHistoryReprojectionPass(const ShaderHashesList<OneShaderPerPipeline>& original_shader_hashes)
@@ -50,9 +80,13 @@ namespace QuantumBreakUpscaling
    struct Data
    {
       bool debug_prev_had_motion_vectors = false;
+      bool debug_prev_had_clip_depth = false;
+      bool debug_prev_used_cached_clip_depth = false;
 
 #if ENABLE_SR
       // Resources captured or created around the temporal resolve pass.
+      // sr_clip_depth is captured from 0xA43343D6 PS SRV0, the pre-linearized clip/device depth.
+      com_ptr<ID3D11Resource> sr_clip_depth;
       com_ptr<ID3D11Resource> sr_motion_vectors;
       com_ptr<ID3D11Buffer> cb_update_1_readback;
       com_ptr<ID3D11Buffer> ssaa_readback;
@@ -74,9 +108,12 @@ namespace QuantumBreakUpscaling
       // Per-resource history used to decide when DLSS history must reset.
       bool has_ssaa_data = false;
       bool output_changed = false;
+      bool has_sr_clip_depth_desc = false;
+      bool used_cached_clip_depth = false;
       bool has_previous_source_desc = false;
       bool has_previous_depth_desc = false;
       bool has_previous_motion_vectors_desc = false;
+      D3D11_TEXTURE2D_DESC sr_clip_depth_desc = {};
       D3D11_TEXTURE2D_DESC previous_source_desc = {};
       D3D11_TEXTURE2D_DESC previous_depth_desc = {};
       D3D11_TEXTURE2D_DESC previous_motion_vectors_desc = {};
@@ -215,6 +252,62 @@ namespace QuantumBreakUpscaling
 #else
       (void)device_data;
       return false;
+#endif
+   }
+
+   inline void CaptureClipDepthFromLinearizationPass(ID3D11DeviceContext* native_device_context, Data& data)
+   {
+#if ENABLE_SR
+      if (native_device_context->GetType() != D3D11_DEVICE_CONTEXT_IMMEDIATE)
+      {
+         return;
+      }
+
+      // 0xA43343D6 converts clip/device depth to linear depth:
+      //   PS SRV0 = pre-linearized clip depth, viewed as r32_float on an r32_typeless resource.
+      //   RTV0    = linearized r16_float depth output.
+      // SR wants the PS SRV0 input, not the RTV0 output. The pass can run at full/half/quarter res,
+      // so keep the largest depth seen this frame to avoid replacing the main depth with downscaled copies.
+      com_ptr<ID3D11ShaderResourceView> clip_depth_srv;
+      native_device_context->PSGetShaderResources(0, 1, &clip_depth_srv);
+      if (!clip_depth_srv.get())
+      {
+         return;
+      }
+
+      com_ptr<ID3D11Resource> clip_depth_resource;
+      clip_depth_srv->GetResource(&clip_depth_resource);
+      if (!clip_depth_resource.get())
+      {
+         return;
+      }
+
+      com_ptr<ID3D11Texture2D> clip_depth_texture;
+      if (FAILED(clip_depth_resource->QueryInterface(&clip_depth_texture)) || !clip_depth_texture.get())
+      {
+         return;
+      }
+
+      D3D11_TEXTURE2D_DESC clip_depth_desc = {};
+      clip_depth_texture->GetDesc(&clip_depth_desc);
+      if (clip_depth_desc.Width == 0u || clip_depth_desc.Height == 0u)
+      {
+         return;
+      }
+
+      const uint64_t current_area = static_cast<uint64_t>(clip_depth_desc.Width) * static_cast<uint64_t>(clip_depth_desc.Height);
+      const uint64_t previous_area = data.has_sr_clip_depth_desc
+                                        ? (static_cast<uint64_t>(data.sr_clip_depth_desc.Width) * static_cast<uint64_t>(data.sr_clip_depth_desc.Height))
+                                        : 0ull;
+      if (!data.sr_clip_depth.get() || current_area > previous_area)
+      {
+         data.sr_clip_depth = clip_depth_resource;
+         data.sr_clip_depth_desc = clip_depth_desc;
+         data.has_sr_clip_depth_desc = true;
+      }
+#else
+      (void)native_device_context;
+      (void)data;
 #endif
    }
 
@@ -533,6 +626,8 @@ namespace QuantumBreakUpscaling
       result.requested = IsRequested(device_data);
 
 #if ENABLE_SR
+   data.used_cached_clip_depth = false;
+
       com_ptr<ID3D11ShaderResourceView> ps_shader_resources[3];
       com_ptr<ID3D11RenderTargetView> render_target_views[D3D11_SIMULTANEOUS_RENDER_TARGET_COUNT];
       com_ptr<ID3D11DepthStencilView> depth_stencil_view;
@@ -563,8 +658,11 @@ namespace QuantumBreakUpscaling
             com_ptr<ID3D11Resource> source_color_resource;
             ps_shader_resources[2]->GetResource(&source_color_resource);
 
-            com_ptr<ID3D11Resource> depth_resource;
-            ps_shader_resources[0]->GetResource(&depth_resource);
+            // Fallback depth from temporal resolve PS SRV0. Shader 0x99274617 names this g_tClipDepth.
+            // Prefer the cached 0xA43343D6 PS SRV0 resource below when it matches the main render size,
+            // because that cache point explicitly proves the resource is pre-linearized depth.
+            com_ptr<ID3D11Resource> temporal_resolve_depth_resource;
+            ps_shader_resources[0]->GetResource(&temporal_resolve_depth_resource);
 
             // The temporal resolve RTV is the final SR output target size.
             com_ptr<ID3D11Resource> output_resource;
@@ -572,26 +670,44 @@ namespace QuantumBreakUpscaling
 
             com_ptr<ID3D11Texture2D> source_color_texture;
             com_ptr<ID3D11Texture2D> output_texture;
-            com_ptr<ID3D11Texture2D> depth_texture;
+            com_ptr<ID3D11Texture2D> temporal_resolve_depth_texture;
             com_ptr<ID3D11Texture2D> motion_vectors_texture;
 
             const HRESULT source_hr = source_color_resource.get() ? source_color_resource->QueryInterface(&source_color_texture) : E_FAIL;
             const HRESULT output_hr = output_resource.get() ? output_resource->QueryInterface(&output_texture) : E_FAIL;
-            const HRESULT depth_hr = depth_resource.get() ? depth_resource->QueryInterface(&depth_texture) : E_FAIL;
+            const HRESULT temporal_depth_hr = temporal_resolve_depth_resource.get() ? temporal_resolve_depth_resource->QueryInterface(&temporal_resolve_depth_texture) : E_FAIL;
             const HRESULT motion_vectors_hr = data.sr_motion_vectors.get() ? data.sr_motion_vectors->QueryInterface(&motion_vectors_texture) : E_FAIL;
 
-            if (SUCCEEDED(source_hr) && SUCCEEDED(output_hr) && SUCCEEDED(depth_hr) && SUCCEEDED(motion_vectors_hr) && source_color_texture.get() && output_texture.get() && depth_texture.get() && motion_vectors_texture.get())
+            if (SUCCEEDED(source_hr) && SUCCEEDED(output_hr) && SUCCEEDED(temporal_depth_hr) && SUCCEEDED(motion_vectors_hr) && source_color_texture.get() && output_texture.get() && temporal_resolve_depth_texture.get() && motion_vectors_texture.get())
             {
                // Descs drive DLSS settings, conversion texture allocation, and history reset decisions.
                D3D11_TEXTURE2D_DESC source_desc = {};
+               D3D11_TEXTURE2D_DESC temporal_resolve_depth_desc = {};
                D3D11_TEXTURE2D_DESC depth_desc = {};
                D3D11_TEXTURE2D_DESC motion_vectors_desc = {};
                D3D11_TEXTURE2D_DESC output_desc = {};
                // Source/depth/MV descs bound the DLSS input resolution; output desc drives the upscaled target.
                source_color_texture->GetDesc(&source_desc);
-               depth_texture->GetDesc(&depth_desc);
+               temporal_resolve_depth_texture->GetDesc(&temporal_resolve_depth_desc);
                motion_vectors_texture->GetDesc(&motion_vectors_desc);
                output_texture->GetDesc(&output_desc);
+
+               ID3D11Resource* sr_depth_resource = temporal_resolve_depth_resource.get();
+               depth_desc = temporal_resolve_depth_desc;
+
+               // The depth-linearization pass can also produce half/quarter-res linear-depth copies.
+               // Only use the cached clip-depth input if it matches the main color and MV size for this SR draw;
+               // otherwise keep the temporal resolve PS SRV0 fallback, which is also named g_tClipDepth.
+               if (data.sr_clip_depth.get() && data.has_sr_clip_depth_desc &&
+                   data.sr_clip_depth_desc.Width == source_desc.Width &&
+                   data.sr_clip_depth_desc.Height == source_desc.Height &&
+                   data.sr_clip_depth_desc.Width == motion_vectors_desc.Width &&
+                   data.sr_clip_depth_desc.Height == motion_vectors_desc.Height)
+               {
+                  sr_depth_resource = data.sr_clip_depth.get();
+                  depth_desc = data.sr_clip_depth_desc;
+                  data.used_cached_clip_depth = true;
+               }
 
                if (SetupOutput(native_device, device_data, data, output_desc))
                {
@@ -662,7 +778,7 @@ namespace QuantumBreakUpscaling
                         draw_data.source_color = data.sr_linear_input_color.get();
                         draw_data.output_color = device_data.sr_output_color.get();
                         draw_data.motion_vectors = data.sr_motion_vectors.get();
-                        draw_data.depth_buffer = depth_resource.get();
+                        draw_data.depth_buffer = sr_depth_resource;
                         draw_data.pre_exposure = 1.f;
                         draw_data.jitter_x = jitter_x * Settings::jitter_scale;
                         draw_data.jitter_y = jitter_y * Settings::jitter_scale;
@@ -778,16 +894,20 @@ namespace QuantumBreakUpscaling
       device_data.force_reset_sr = true;
       device_data.has_drawn_sr = false;
 
+      data.sr_clip_depth = nullptr;
       data.sr_motion_vectors = nullptr;
       data.sr_linear_input_color = nullptr;
       data.sr_linear_input_color_srv = nullptr;
       data.sr_linear_input_color_rtv = nullptr;
       data.sr_output_color_srv = nullptr;
       data.output_changed = false;
+      data.has_sr_clip_depth_desc = false;
+      data.used_cached_clip_depth = false;
 
       data.has_previous_source_desc = false;
       data.has_previous_depth_desc = false;
       data.has_previous_motion_vectors_desc = false;
+      data.sr_clip_depth_desc = {};
       data.previous_source_desc = {};
       data.previous_depth_desc = {};
       data.previous_motion_vectors_desc = {};
@@ -810,11 +930,19 @@ namespace QuantumBreakUpscaling
          device_data.force_reset_sr = true;
       }
 
+      data.debug_prev_had_clip_depth = data.sr_clip_depth.get() != nullptr;
       data.debug_prev_had_motion_vectors = data.sr_motion_vectors.get() != nullptr;
+      data.debug_prev_used_cached_clip_depth = data.used_cached_clip_depth;
+      data.sr_clip_depth = nullptr;
       data.sr_motion_vectors = nullptr;
+      data.has_sr_clip_depth_desc = false;
+      data.sr_clip_depth_desc = {};
+      data.used_cached_clip_depth = false;
       data.output_changed = false;
 #else
+      data.debug_prev_had_clip_depth = false;
       data.debug_prev_had_motion_vectors = false;
+      data.debug_prev_used_cached_clip_depth = false;
       (void)device_data;
 #endif
 
@@ -877,7 +1005,9 @@ namespace QuantumBreakUpscaling
          {
             table_row_bool("History Reprojection Pass Seen:", saw_history_reprojection_pass);
             table_row_bool("Temporal Resolve Pass Seen:", saw_temporal_resolve_pass);
+            table_row_bool("Clip Depth Captured:", data.debug_prev_had_clip_depth);
             table_row_bool("Motion Vectors Captured:", data.debug_prev_had_motion_vectors);
+            table_row_bool("Cached Clip Depth Used For SR:", data.debug_prev_used_cached_clip_depth);
             table_row_bool("Had Scene Temporal Resolve Last Frame:", had_scene_temporal_resolve_last_frame);
             table_row_uint("UI-Only Hold Frames:", ui_only_frame_hold_counter);
             ImGui::EndTable();

--- a/Source/Games/Quantum Break/UpscalingNotes.md
+++ b/Source/Games/Quantum Break/UpscalingNotes.md
@@ -8,6 +8,7 @@ Relevant files:
 
 - `Source/Games/Quantum Break/main.cpp`
 - `Source/Games/Quantum Break/Upscaling.hpp`
+- `Source/Games/Quantum Break/Quantum Break.vcxproj`
 - `Shaders/Quantum Break/Luma_QB_PreSRDecode.hlsl`
 - `Shaders/Quantum Break/temporal_resolve_0x99274617.ps_5_0.hlsl`
 - `Shaders/Quantum Break/unused/history_reprojection_clamp_0xE8337D48.cs_5_0.hlsl`
@@ -23,6 +24,8 @@ Quantum Break enables:
 ```
 
 The post draw/dispatch callback is required because Luma temporarily replaces the temporal resolve color SRV with the SR result, executes the game's original resolve draw, then restores the original binding.
+
+The Visual Studio project copies the built addon and, for symbol-producing configurations, the matching PDB to `LUMA_QUANTUM_BREAK_BIN_PATH`. That keeps the deployed addon debuggable when Quantum Break prompts for manual debugger attach.
 
 ## Hook Points
 
@@ -56,7 +59,7 @@ History reprojection pass:
 - Suggested name: `QB History Reprojection (Motion Vectors)`.
 - Marks TAA detected.
 - Captures motion vectors from `CS SRV slot 0`.
-- Stores the resource in `game_device_data.sr_motion_vectors`.
+- Stores the resource in `game_device_data.upscaling.sr_motion_vectors`.
 
 Temporal resolve pass:
 
@@ -104,10 +107,10 @@ Depth chain summary:
 SR render/input resolution is taken from actual texture dimensions, not cbuffer resolution fields:
 
 ```cpp
-const uint32_t max_input_width = min(source_desc.Width, depth_desc.Width, motion_vectors_desc.Width);
-const uint32_t max_input_height = min(source_desc.Height, depth_desc.Height, motion_vectors_desc.Height);
-const uint32_t render_width = max_input_width;
-const uint32_t render_height = max_input_height;
+const uint32_t input_width = min(source_desc.Width, depth_desc.Width, motion_vectors_desc.Width);
+const uint32_t input_height = min(source_desc.Height, depth_desc.Height, motion_vectors_desc.Height);
+const uint32_t render_width = input_width;
+const uint32_t render_height = input_height;
 ```
 
 SR output resolution is taken from the temporal resolve RTV:
@@ -149,7 +152,7 @@ Pre-SR decode:
 - Shader: `Luma_QB_PreSRDecode.hlsl`
 - Input: temporal resolve color from `PS SRV slot 2`.
 - Operation: `gamma_sRGB_to_linear(..., GCT_POSITIVE)`.
-- Output: `game_device_data.sr_linear_input_color`.
+- Output: `game_device_data.upscaling.sr_linear_input_color`.
 
 Post-SR encode is now in `temporal_resolve_0x99274617.ps_5_0.hlsl` when `LumaSettings.SRType > 0`:
 
@@ -187,7 +190,7 @@ Current `SR::SuperResolutionImpl::DrawData`:
 - `motion_vectors`: captured history reprojection motion-vector resource
 - `depth_buffer`: cached `A43343D6` depth-linearization `PS SRV slot 0` resource when it matches source color and motion-vector resolution; otherwise temporal resolve `PS SRV slot 0` fallback
 - `pre_exposure`: `1.f`
-- `jitter_x/y`: SSAA jitter if available, otherwise `cb_update_1` jitter
+- `jitter_x/y`: chosen raw QB jitter converted to SR input/render pixel space
 - `vert_fov`: derived from projection scale, fallback `0.775934f`
 - `near_plane`: derived from `g_fInvNear`
 - `far_plane`: fixed `1000.f`
@@ -211,7 +214,66 @@ Important resolution naming quirk:
 
 - `g_vSSAAJitterOffset[0]`, preferred DLSS jitter source.
 
-The temporal resolve shader samples current color with `g_vSSAAJitterOffset[0]`, so this remains the most authoritative jitter source until proven otherwise.
+The temporal resolve shader samples current color/depth with `g_vSSAAJitterOffset[0]` added directly to UVs, so this remains the most authoritative jitter source until proven otherwise.
+
+## Jitter Units
+
+Raw jitter source priority:
+
+1. `ssaa` `PS CB1` at `g_vSSAAJitterOffset[0]`.
+2. `cb_update_1` `PS CB0` at `g_vJitterOffset` as fallback.
+
+The raw QB jitter is kept in `cb_luma_global_settings.GameSettings.JitterOffset` for any QB/Luma shader code that needs to reason in the game's original units.
+
+The SR backend receives render-pixel jitter, because DLSS/FSR expect offsets in input pixel space rather than the raw QB cbuffer units:
+
+```cpp
+if (using_ssaa_jitter)
+{
+	// g_vSSAAJitterOffset[0] is already a normalized UV offset.
+	sr_jitter_x = raw_ssaa_jitter_x * render_width;
+	sr_jitter_y = -raw_ssaa_jitter_y * render_height;
+}
+else
+{
+	// cb_update_1.g_vJitterOffset is less authoritative and appears pixel-space in other QB shaders.
+	sr_jitter_x = raw_cb_jitter_x;
+	sr_jitter_y = -raw_cb_jitter_y;
+}
+```
+
+The Y sign is flipped to match the SR convention used by the other Luma integrations.
+
+Before this change, DLSS received QB's tiny raw cbuffer jitter values directly. This change converts the authoritative SSAA jitter to render-pixel units and fixes the Y sign. `g_vSSAAJitterOffset[0]` is a UV offset, so it must use full render-size scaling; a projection/NDC-style `* 0.5f` conversion would make the actual game pattern half-strength.
+
+Captured scene logs show `cb_update_1.g_vJitterOffset` as zero on relevant frames. Other QB shaders add `g_vJitterOffset` to `SV_Position`, which means the fallback should not be multiplied by render size if it ever becomes non-zero. The meaningful temporal resolve input is `ssaa.g_vSSAAJitterOffset[0]`, which repeats this 4-sample UV sequence:
+
+```text
+( 0.00014648, -0.00008681 )
+( -0.00014648,  0.00008681 )
+( 0.00004883,  0.00026042 )
+( -0.00004883, -0.00026042 )
+```
+
+At a 2560x1440 render size, which is the observed internal render resolution when QB's own upscaling option is enabled for 4K output, that maps to this SR pixel-space sequence after the Y flip:
+
+```text
+( 0.375,  0.125 )
+( -0.375, -0.125 )
+( 0.125, -0.375 )
+( -0.125,  0.375 )
+```
+
+With an incorrect projection-style `* 0.5f` conversion, DLSS would receive only:
+
+```text
+( 0.1875,  0.0625 )
+( -0.1875, -0.0625 )
+( 0.0625, -0.1875 )
+( -0.0625,  0.1875 )
+```
+
+The current implementation only fixes units/sign/amplitude for the jitter already produced by QB. Replacing or overriding QB's hardcoded 4-sample pattern with a longer Halton sequence should be a separate follow-up improvement so regressions can be bisected cleanly.
 
 ## FOV And Camera Data
 
@@ -263,6 +325,22 @@ Pause/menu detection:
 - Tracks whether scene temporal resolve was seen this frame.
 - Holds pause state across the swapchain queue to avoid treating UI-only frames as active gameplay.
 
+Loading/transition guards:
+
+- Temporal-resolve draws that bind the main color/depth/output resources but expose neither `cb_update_1` nor `ssaa` are treated as non-scene transition variants.
+- For those transition variants, SR is reset, `LumaSettings.SRType` is cleared, `TemporalResolveResult::stop_processing` is set, and `main.cpp` skips the original draw. This prevents the draw from being replayed through the post-SR resolve path.
+- DLSS is warmed up after switching to DLSS, rebuilding SR resources, or observing a no-scene/title/loading frame.
+- The warmup is counted in valid scene temporal-resolve draws, not wall-clock seconds. `dlss_scene_warmup_resolve_count` is currently `120`.
+- During the warmup window, valid scene temporal resolves run QB's normal temporal resolve and DLSS is skipped with `force_reset_sr` left set. This keeps DLSS history empty until the scene pipeline is stable.
+- This avoids the AA-off save-load device hang seen when DLSS started on the first unstable gameplay resolves after title/loading.
+
+Observed failure that motivated the guard:
+
+- None and FSR could load saves.
+- DLSS selected after loading a save worked.
+- DLSS selected before loading a save could hang the D3D device when Quantum Break's in-game Anti Aliasing option was off.
+- The failing path reached a temporal resolve with scene-looking resources but missing both scene constant buffers. The later `CreateRenderTargetView` assert in Luma core was secondary to `DXGI_ERROR_DEVICE_REMOVED` / `DXGI_ERROR_DEVICE_HUNG`, not the root cause.
+
 ## Debug UI
 
 In development/test builds, collapsible SR debug sections show:
@@ -275,6 +353,10 @@ In development/test builds, collapsible SR debug sections show:
 - UI-only hold frames
 - last SR render size
 - last SR output size
+- active jitter source
+- raw SSAA jitter
+- raw `cb_update_1` jitter
+- SR render-pixel jitter sent to DLSS/FSR
 - MV scale multiplier
 - jitter scale multiplier
 
@@ -285,21 +367,28 @@ User tuning controls:
 FSR sharpness is fixed at `0.f`.
 MV scale and jitter scale are fixed at `1.f`.
 
-## Current Open Questions
+## Validation Status And Follow-Ups
 
-Main remaining validation work:
+Validated in this work:
 
-- Confirm `Clip Depth Captured` and `Cached Clip Depth Used For SR` are both true during gameplay SR draws.
-- Confirm MV scale and sign. Current fixed scale is `render_width/height`.
-- Confirm jitter sign and units. Current fixed scale is `1.f`.
+- SR depth is sourced from the pre-linearized depth-linearization input instead of the linearized depth output.
+- Raw QB jitter is converted to SR render-pixel units before being sent to DLSS/FSR; the preferred SSAA jitter path uses full UV-to-pixel scaling, not raw cbuffer values or half-amplitude projection conversion.
+- DLSS selected before loading a save no longer hangs on the AA-off path after the transition guard and DLSS warmup.
+- The Luma core `CreateRenderTargetView` assert observed during debugging was a secondary symptom of device removal, so no core workaround is kept.
+
+Remaining validation/follow-up work:
+
+- Confirm MV scale and sign over more camera motion. Current fixed scale is `render_width/height`.
+- Consider a separate Halton/game jitter-table patch after the unit/sign/amplitude fix is stable enough to bisect separately.
 - Confirm whether FSR behaves best with the same linear/HDR path used for DLSS.
 - Derive far plane if a reliable source is found.
-- Validate color stability with the gamma->linear->SR->gamma path.
-- Validate render/output sizes in the debug UI across gameplay, menus, cutscenes, and resolution changes.
+- Validate color stability with the gamma->linear->SR->gamma path across gameplay, menus, cutscenes, and resolution changes.
+- Replace the conservative `120`-resolve DLSS warmup with a tighter state-based stability check if a reliable signal is found.
 
 Most useful runtime checks:
 
 1. Confirm `Last SR Render Width/Height` matches the source/depth/MV texture resolution.
 2. Confirm `Last SR Output Width/Height` matches the actual final output resolution.
 3. Confirm the cached clip-depth path stays selected with MSAA off; MSAA reconstruction/resolve hashes should not appear in that mode.
-4. Test camera cuts, pause/menu transitions, loading, and resolution changes.
+4. Test DLSS selected before save load with Anti Aliasing off.
+5. Test camera cuts, pause/menu transitions, loading, and resolution changes.

--- a/Source/Games/Quantum Break/UpscalingNotes.md
+++ b/Source/Games/Quantum Break/UpscalingNotes.md
@@ -7,6 +7,7 @@ These notes describe the current Quantum Break SR/DLSS integration in Luma.
 Relevant files:
 
 - `Source/Games/Quantum Break/main.cpp`
+- `Source/Games/Quantum Break/Upscaling.hpp`
 - `Shaders/Quantum Break/Luma_QB_PreSRDecode.hlsl`
 - `Shaders/Quantum Break/temporal_resolve_0x99274617.ps_5_0.hlsl`
 - `Shaders/Quantum Break/unused/history_reprojection_clamp_0xE8337D48.cs_5_0.hlsl`
@@ -28,13 +29,31 @@ The post draw/dispatch callback is required because Luma temporarily replaces th
 Shader hashes:
 
 ```cpp
-shader_hashes_history_reprojection.compute_shaders.emplace(std::stoul("E8337D48", nullptr, 16));
-shader_hashes_temporal_resolve.pixel_shaders.emplace(std::stoul("99274617", nullptr, 16));
+DepthLinearizationHashes().pixel_shaders.emplace(hash_depth_linearization);
+HistoryReprojectionHashes().compute_shaders.emplace(hash_history_reprojection);
+TemporalResolveHashes().pixel_shaders.emplace(hash_temporal_resolve);
 ```
+
+Development builds also force shader names into Luma's debugger:
+
+- `0xA43343D6`: `QB Depth Linearization (Clip Depth -> Linear Depth)`
+- `0xE8337D48`: `QB History Reprojection (Motion Vectors)`
+- `0x99274617`: `QB Temporal Resolve / TAA`
+- `0x037FCE62`: `QB MSAA GBuffer Reconstruction Mask`
+- `0x84DD3C0C`: `QB MSAA GBuffer Depth Resolve`
+
+Depth linearization pass:
+
+- Pixel shader hash `A43343D6`.
+- Suggested name: `QB Depth Linearization (Clip Depth -> Linear Depth)`.
+- Captures clip/device depth from `PS SRV slot 0`.
+- The shader writes linear depth to `OM RTV slot 0`, but Luma deliberately does **not** use that output for SR.
+- The pass can run at full, half, and quarter resolution. Luma keeps the largest captured `PS SRV 0` resource each frame so downscaled linear-depth passes cannot replace main scene depth.
 
 History reprojection pass:
 
 - Compute shader hash `E8337D48`.
+- Suggested name: `QB History Reprojection (Motion Vectors)`.
 - Marks TAA detected.
 - Captures motion vectors from `CS SRV slot 0`.
 - Stores the resource in `game_device_data.sr_motion_vectors`.
@@ -42,12 +61,43 @@ History reprojection pass:
 Temporal resolve pass:
 
 - Pixel shader hash `99274617`.
+- Suggested name: `QB Temporal Resolve / TAA`.
 - Main SR insertion point.
-- Captures depth from `PS SRV slot 0`.
+- Uses cached clip/device depth from the `A43343D6` depth-linearization input when it matches source color and motion-vector size.
+- Falls back to temporal resolve `PS SRV slot 0`, named `g_tClipDepth` in the shader dump, if the explicit depth cache is missing or mismatched.
 - Captures source color from `PS SRV slot 2`.
 - Captures final resolve RTV from `OM RTV slot 0`.
 - Reads only the SR-required values from `cb_update_1` and the temporal resolve `ssaa` cbuffer through staging readback.
 - Runs SR before executing the original temporal resolve draw.
+
+MSAA-specific depth path:
+
+- `0x037FCE62`: MSAA GBuffer/depth reconstruction mask, reads `Texture2DMS<float> g_tDepthMS`.
+- `0x84DD3C0C`: MSAA GBuffer/depth resolve, reads `Texture2DMS<float> g_tDepthMS` and writes `SV_Depth`.
+- These disappear when the in-game AA option disables MSAA.
+- They are not used as SR depth inputs because they are the MSAA path, not the stable single-sample clip-depth resource used by temporal resolve.
+
+## SR Input Map
+
+Every SR input is taken from a specific QB pass/binding:
+
+| SR input | Source pass | Binding | Resource meaning |
+|---|---|---|---|
+| Source color | `0x99274617` Temporal Resolve | `PS SRV2` / `g_tColor` | Current temporal color at render resolution, still in QB gamma-space before Luma decodes it. |
+| Depth | `0xA43343D6` Depth Linearization | `PS SRV0` | Pre-linearized clip/device depth, viewed as `r32_float` on an `r32_typeless` resource. This is the preferred SR depth. |
+| Depth fallback | `0x99274617` Temporal Resolve | `PS SRV0` / `g_tClipDepth` | Same kind of clip-depth resource, used only if the explicit `0xA43343D6` cache is missing or size-mismatched. |
+| Motion vectors | `0xE8337D48` History Reprojection | `CS SRV0` / `g_tGeometryVelocityTexture` | Geometry velocity texture, observed as `r16g16_float` at render resolution. |
+| Output color | `0x99274617` Temporal Resolve | `OM RTV0` | Final temporal resolve target, normally output/upscaled resolution. |
+| Main camera constants | `0x99274617` Temporal Resolve | `PS CB0` / `cb_update_1` | Near plane, projection scale/FOV fallback, and cbuffer jitter fallback. |
+| Temporal jitter | `0x99274617` Temporal Resolve | `PS CB1` / `ssaa` | `g_vSSAAJitterOffset[0]`, the jitter used by the temporal resolve when sampling current color. |
+
+Depth chain summary:
+
+```text
+0xA43343D6 PS SRV0   clip/device depth      -> Luma SR depth cache
+0xA43343D6 RTV0      linear r16 depth       -> not used for SR
+0x99274617 PS SRV0   g_tClipDepth fallback  -> used only if cache is unavailable
+```
 
 ## Resolution Source
 
@@ -117,8 +167,8 @@ settings_data.hdr = true;
 settings_data.auto_exposure = false;
 settings_data.inverted_depth = false;
 settings_data.mvs_jittered = false;
-settings_data.mvs_x_scale = static_cast<float>(render_width) * Settings::SuperResolution::mv_scale;
-settings_data.mvs_y_scale = static_cast<float>(render_height) * Settings::SuperResolution::mv_scale;
+settings_data.mvs_x_scale = static_cast<float>(render_width) * Settings::mv_scale;
+settings_data.mvs_y_scale = static_cast<float>(render_height) * Settings::mv_scale;
 settings_data.render_preset = dlss_render_preset;
 ```
 
@@ -135,7 +185,7 @@ Current `SR::SuperResolutionImpl::DrawData`:
 - `source_color`: `sr_linear_input_color`
 - `output_color`: `device_data.sr_output_color`
 - `motion_vectors`: captured history reprojection motion-vector resource
-- `depth_buffer`: temporal resolve `PS SRV slot 0`
+- `depth_buffer`: cached `A43343D6` depth-linearization `PS SRV slot 0` resource when it matches source color and motion-vector resolution; otherwise temporal resolve `PS SRV slot 0` fallback
 - `pre_exposure`: `1.f`
 - `jitter_x/y`: SSAA jitter if available, otherwise `cb_update_1` jitter
 - `vert_fov`: derived from projection scale, fallback `0.775934f`
@@ -219,7 +269,9 @@ In development/test builds, collapsible SR debug sections show:
 
 - history reprojection pass seen
 - temporal resolve pass seen
+- clip depth captured from the depth-linearization pass
 - motion vectors captured
+- whether cached clip depth was used for the last SR draw
 - UI-only hold frames
 - last SR render size
 - last SR output size
@@ -237,6 +289,7 @@ MV scale and jitter scale are fixed at `1.f`.
 
 Main remaining validation work:
 
+- Confirm `Clip Depth Captured` and `Cached Clip Depth Used For SR` are both true during gameplay SR draws.
 - Confirm MV scale and sign. Current fixed scale is `render_width/height`.
 - Confirm jitter sign and units. Current fixed scale is `1.f`.
 - Confirm whether FSR behaves best with the same linear/HDR path used for DLSS.
@@ -248,4 +301,5 @@ Most useful runtime checks:
 
 1. Confirm `Last SR Render Width/Height` matches the source/depth/MV texture resolution.
 2. Confirm `Last SR Output Width/Height` matches the actual final output resolution.
-3. Test camera cuts, pause/menu transitions, loading, and resolution changes.
+3. Confirm the cached clip-depth path stays selected with MSAA off; MSAA reconstruction/resolve hashes should not appear in that mode.
+4. Test camera cuts, pause/menu transitions, loading, and resolution changes.

--- a/Source/Games/Quantum Break/main.cpp
+++ b/Source/Games/Quantum Break/main.cpp
@@ -382,7 +382,10 @@ public:
       const auto sr_result = QuantumBreakUpscaling::RunTemporalResolve(native_device, native_device_context, device_data, game_device_data.upscaling);
       if (sr_result.stop_processing)
       {
-         return DrawOrDispatchOverrideType::None;
+         // Some loading-to-gameplay temporal-resolve variants bind color/depth/MV but not QB's scene
+         // constant buffers. Running or replaying that draw after DLSS work can hang the D3D device, so
+         // drop it and wait for the next proper scene temporal resolve.
+         return DrawOrDispatchOverrideType::Skip;
       }
 
       QuantumBreakUpscaling::SetSRTypeForTemporalResolve(device_data, sr_result.succeeded);

--- a/Source/Games/Quantum Break/main.cpp
+++ b/Source/Games/Quantum Break/main.cpp
@@ -354,6 +354,13 @@ public:
    {
       auto& game_device_data = GetGameDeviceData(device_data);
 
+      if (QuantumBreakUpscaling::IsDepthLinearizationPass(original_shader_hashes))
+      {
+         QuantumBreakUpscaling::CaptureClipDepthFromLinearizationPass(native_device_context, game_device_data.upscaling);
+
+         return DrawOrDispatchOverrideType::None;
+      }
+
       if (QuantumBreakUpscaling::IsHistoryReprojectionPass(original_shader_hashes))
       {
          game_device_data.saw_history_reprojection_pass = true;


### PR DESCRIPTION
## Summary

This improves the Quantum Break super-resolution path by fixing the depth source used for upscaling, correcting the jitter values passed to DLSS/FSR, and hardening DLSS startup across loading-to-gameplay transitions.

## Changes

- Source SR depth from the depth-linearization pass input instead of the already-linearized output.
- Cache the pre-linearized clip/device depth from `0xA43343D6` `PS SRV0`.
- Prefer `ssaa.g_vSSAAJitterOffset[0]` as the authoritative temporal jitter source.
- Convert SSAA jitter from normalized UV units to DLSS/FSR input pixel units.
- Flip jitter Y to match the SR convention.
- Treat `cb_update_1.g_vJitterOffset` as already pixel-space if it is ever used.
- Add transition guards for temporal-resolve variants missing valid scene constant buffers.
- Skip invalid transition resolves instead of replaying them through the post-SR path.
- Add DLSS scene warmup counted in valid temporal resolves.
- Keep DLSS history reset across no-scene/title/loading periods and SR resource rebuilds.
- Copy generated PDBs for symbol-producing Quantum Break addon configurations.
- Update `UpscalingNotes.md` with the current SR input map, jitter behavior, transition handling, and validation status.

## Notes

The logged Quantum Break jitter sequence is a 4-sample pattern sourced from `g_vSSAAJitterOffset[0]`. At the observed `2560x1440` internal render size used by QB's own upscaling at 4K output, it maps to:

```text
( 0.375,  0.125 )
( -0.375, -0.125 )
( 0.125, -0.375 )
( -0.125,  0.375 )